### PR TITLE
Fix void names.

### DIFF
--- a/src/lib/CombatCalc.ts
+++ b/src/lib/CombatCalc.ts
@@ -85,7 +85,7 @@ export default class CombatCalc {
    * @see https://oldschool.runescape.wiki/w/Elite_Void_Knight_equipment
    */
   private isWearingEliteRangedVoid(): boolean {
-    return this.wearingAll(['Void ranged helm', 'Elite void top', 'Elite void robe', 'Void knight gloves']);
+    return this.wearingAll(['Void ranger helm', 'Elite void top', 'Elite void robe', 'Void knight gloves']);
   }
 
   /**
@@ -93,7 +93,7 @@ export default class CombatCalc {
    * @see https://oldschool.runescape.wiki/w/Elite_Void_Knight_equipment
    */
   private isWearingEliteMagicVoid(): boolean {
-    return this.wearingAll(['Void magic helm', 'Elite void top', 'Elite void robe', 'Void knight gloves']);
+    return this.wearingAll(['Void mage helm', 'Elite void top', 'Elite void robe', 'Void knight gloves']);
   }
 
   /**
@@ -109,7 +109,7 @@ export default class CombatCalc {
    * @see https://oldschool.runescape.wiki/w/Void_Knight_equipment
    */
   private isWearingMagicVoid(): boolean {
-    return this.wearingAll(['Void magic helm', 'Void knight top', 'Void knight robe', 'Void knight gloves']);
+    return this.wearingAll(['Void mage helm', 'Void knight top', 'Void knight robe', 'Void knight gloves']);
   }
 
   /**


### PR DESCRIPTION
The wrong names were set for ranger and mage void helms when checking if the full set was equipped. It might be a good idea to use enums to avoid these kinds of typos, but it would probably end up being a very long list.

https://oldschool.runescape.wiki/w/Void_ranger_helm
https://oldschool.runescape.wiki/w/Void_mage_helm

**Additionally**: this also doesn't work for the ornamental versions.
https://oldschool.runescape.wiki/w/Void_ranger_helm_(or)
https://oldschool.runescape.wiki/w/Void_mage_helm_(or)
https://oldschool.runescape.wiki/w/Void_melee_helm_(or)