### PR TITLE
Use defence stat for Ice demon style monsters

### DIFF
--- a/src/constants.ts
+++ b/src/constants.ts
@@ -130,6 +130,36 @@ export const GLOWING_CRYSTAL_IDS = [
   7568,
 ];
 
+/**
+ * IDs of the Ice demon from the Chambers of Xeric.
+ */
+export const ICE_DEMON_IDS = [
+  7584, // reg
+  7585, // cm
+];
+
+/**
+ * IDs of the Fragment of Seren
+ */
+export const FRAGMENT_OF_SEREN_IDS = [
+  8917, 8918, 8919, 8920
+];
+
+/**
+ * IDs of monsters that calculate their magical defence using the defence stat
+ * https://twitter.com/JagexAsh/status/1689566945635438592
+ **/
+export const ICE_DEMON_STYLE_DEF_IDS = [
+  ...ICE_DEMON_IDS,
+  ...VERZIK_P1_IDS,
+  10833, 10834, 10835, // verzik entry mode
+  8372, 8373, 8374, // verzik normal mode
+  10850, 10851, 10852, // verzik hard mode
+  ...FRAGMENT_OF_SEREN_IDS,
+  11709, 11712, // baboon brawler
+  9118 // rabbit (prifddinas)
+];
+
 export const PARTY_SIZE_REQUIRED_MONSTER_IDS = [
   ...TOMBS_OF_AMASCUT_MONSTER_IDS,
   ...TOB_MONSTER_IDS,

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -139,14 +139,14 @@ export const ICE_DEMON_IDS = [
 ];
 
 /**
- * IDs of the Fragment of Seren
+ * IDs of the Fragment of Seren.
  */
 export const FRAGMENT_OF_SEREN_IDS = [
   8917, 8918, 8919, 8920
 ];
 
 /**
- * IDs of monsters that calculate their magical defence using the defence stat
+ * IDs of monsters that calculate their magical defence using the defence stat.
  * https://twitter.com/JagexAsh/status/1689566945635438592
  **/
 export const ICE_DEMON_STYLE_DEF_IDS = [

--- a/src/constants.ts
+++ b/src/constants.ts
@@ -27,6 +27,13 @@ export const VERZIK_P1_IDS = [
   10847, 10848, 10849 // hmt
 ];
 
+export const VERZIK_IDS = [
+  ...VERZIK_P1_IDS,
+  10833, 10834, 10835, // verzik entry mode
+  8372, 8373, 8374, // verzik normal mode
+  10850, 10851, 10852, // verzik hard mode
+];
+
 /** IDs of monsters that are present in Theatre of Blood **/
 export const TOB_MONSTER_IDS = [
   ...VERZIK_P1_IDS,
@@ -149,12 +156,9 @@ export const FRAGMENT_OF_SEREN_IDS = [
  * IDs of monsters that calculate their magical defence using the defence stat.
  * https://twitter.com/JagexAsh/status/1689566945635438592
  **/
-export const ICE_DEMON_STYLE_DEF_IDS = [
+export const USES_DEFENCE_LEVEL_FOR_MAGIC_DEFENCE_NPC_IDS = [
   ...ICE_DEMON_IDS,
-  ...VERZIK_P1_IDS,
-  10833, 10834, 10835, // verzik entry mode
-  8372, 8373, 8374, // verzik normal mode
-  10850, 10851, 10852, // verzik hard mode
+  ...VERZIK_IDS,
   ...FRAGMENT_OF_SEREN_IDS,
   11709, 11712, // baboon brawler
   9118 // rabbit (prifddinas)

--- a/src/lib/CombatCalc.ts
+++ b/src/lib/CombatCalc.ts
@@ -11,7 +11,7 @@ import {isBindSpell, isFireSpell, isWaterSpell} from "@/types/Spell";
 import {PrayerMap} from "@/enums/Prayer";
 import {sum} from "d3-array";
 import {isVampyre, MonsterAttribute} from "@/enums/MonsterAttribute";
-import {TOMBS_OF_AMASCUT_MONSTER_IDS, VERZIK_P1_IDS} from "@/constants";
+import {ICE_DEMON_STYLE_DEF_IDS, TOMBS_OF_AMASCUT_MONSTER_IDS, VERZIK_P1_IDS} from "@/constants";
 
 const DEFAULT_ATTACK_SPEED = 4;
 const SECONDS_PER_TICK = 0.6;
@@ -261,7 +261,7 @@ export default class CombatCalc {
    * Get the NPC defence roll for this loadout, which is based on the player's current combat style
    */
   public getNPCDefenceRoll(): number {
-    let effectiveLevel = this.player.style.type === "magic"
+    let effectiveLevel = this.player.style.type === "magic" && !ICE_DEMON_STYLE_DEF_IDS.includes(this.monster.id || 0)
         ? this.monster.skills.magic
         : this.monster.skills.def;
 

--- a/src/lib/CombatCalc.ts
+++ b/src/lib/CombatCalc.ts
@@ -11,7 +11,7 @@ import {isBindSpell, isFireSpell, isWaterSpell} from "@/types/Spell";
 import {PrayerMap} from "@/enums/Prayer";
 import {sum} from "d3-array";
 import {isVampyre, MonsterAttribute} from "@/enums/MonsterAttribute";
-import {ICE_DEMON_STYLE_DEF_IDS, TOMBS_OF_AMASCUT_MONSTER_IDS, VERZIK_P1_IDS} from "@/constants";
+import {USES_DEFENCE_LEVEL_FOR_MAGIC_DEFENCE_NPC_IDS, TOMBS_OF_AMASCUT_MONSTER_IDS, VERZIK_P1_IDS} from "@/constants";
 
 const DEFAULT_ATTACK_SPEED = 4;
 const SECONDS_PER_TICK = 0.6;
@@ -261,7 +261,7 @@ export default class CombatCalc {
    * Get the NPC defence roll for this loadout, which is based on the player's current combat style
    */
   public getNPCDefenceRoll(): number {
-    let effectiveLevel = this.player.style.type === "magic" && !ICE_DEMON_STYLE_DEF_IDS.includes(this.monster.id || 0)
+    let effectiveLevel = this.player.style.type === "magic" && !USES_DEFENCE_LEVEL_FOR_MAGIC_DEFENCE_NPC_IDS.includes(this.monster.id || 0)
         ? this.monster.skills.magic
         : this.monster.skills.def;
 


### PR DESCRIPTION
There's a few monsters that use the defence stat instead of magic when calculating magic defence (like Ice demon).

https://twitter.com/JagexAsh/status/1689566945635438592

I'm really not sure the best thing to name the constant list of IDs. I chose `ICE_DEMON_STYLE_DEF_IDS` because it's most commonly known as the way Ice demon works.

The Bitterkoekje sheet calls it "Def lvl for Mage MDR" so maybe `DEF_LEVEL_FOR_MAGE_DEFENCE_IDS` or `DEF_STAT_FOR_MAGE_DEFENCE_IDS`?
![image](https://github.com/weirdgloop/osrs-dps-calc/assets/7608429/4b39abec-ea24-4d77-87cd-42f48a2fe963)
