### PR TITLE
Update filter height to not make it too small

### DIFF
--- a/src/app/components/generic/Combobox.tsx
+++ b/src/app/components/generic/Combobox.tsx
@@ -175,7 +175,7 @@ const Combobox = <T extends ComboboxItem>(props: IComboboxProps<T>) => {
             <List
               ref={listRef}
               itemSize={getRowHeight}
-              height={(filteredItems.length < 10 ? filteredItems.length * 29 : 200)}
+              height={(filteredItems.length < 6 ? filteredItems.length * 35 : 200)}
               estimatedItemSize={35}
               itemCount={filteredItems.length}
               width={300}


### PR DESCRIPTION
Closes https://github.com/weirdgloop/osrs-dps-calc/issues/71


| Entries| Height | 
| ------ |:-------:|
| 1        | 35px |
| 2        | 70px |
| 3        | 105px |
| 4        | 140px |
| 5        | 175px |
| 6+        | 200px |


![image](https://github.com/weirdgloop/osrs-dps-calc/assets/7608429/43ac5325-be84-4b72-b153-415f60114749)
