### PR TITLE
Only block keyboard events when they're handled

### DIFF
--- a/src/app/home.tsx
+++ b/src/app/home.tsx
@@ -64,7 +64,7 @@ const Home: NextPage = observer(() => {
         break;
       }
       default:
-        break;
+        return;
     }
 
     // If we get here, we've handled the event, so prevent it bubbling


### PR DESCRIPTION
Previously, this code was consuming keyboard events for anything which wasn't being entered into some input field, regardless of whether it was being handled. This commit ensures uhandled inputs exit this handler before being consumed.

Fixes #95