### PR TITLE
calc extended details + tests demo

### DIFF
--- a/src/lib/CalcDetails.ts
+++ b/src/lib/CalcDetails.ts
@@ -1,0 +1,47 @@
+import { sort } from 'd3-array';
+
+export enum DetailKey {
+  DEFENCE_ROLL_LEVEL = 'Defence level',
+  DEFENCE_ROLL_EFFECTIVE_LEVEL = 'Defence effective level',
+  DEFENCE_ROLL_BASE = 'Base defence roll',
+  DEFENCE_ROLL_TOA = 'ToA defence roll',
+  DEFENCE_ROLL_FINAL = 'Defence roll',
+}
+
+export interface DetailEntry {
+  label: DetailKey,
+  value: number,
+}
+
+const OUTPUT_ORDER: DetailKey[] = [
+  DetailKey.DEFENCE_ROLL_LEVEL,
+  DetailKey.DEFENCE_ROLL_EFFECTIVE_LEVEL,
+  DetailKey.DEFENCE_ROLL_BASE,
+  DetailKey.DEFENCE_ROLL_TOA,
+  DetailKey.DEFENCE_ROLL_FINAL,
+];
+
+export class CalcDetails {
+  private readonly entries: Map<DetailKey, DetailEntry> = new Map();
+
+  private _lines: DetailEntry[] = [];
+
+  private dirty: boolean = true;
+
+  public track(label: DetailKey, value: number) {
+    this.dirty = true;
+    this.entries.set(label, {
+      label,
+      value,
+    });
+  }
+
+  public get lines(): DetailEntry[] {
+    if (this.dirty) {
+      this._lines = sort(this.entries.values(), (l) => OUTPUT_ORDER.indexOf(l.label));
+      this.dirty = false;
+    }
+
+    return this._lines;
+  }
+}

--- a/src/tests/calc/DefenceRolls.test.ts
+++ b/src/tests/calc/DefenceRolls.test.ts
@@ -1,0 +1,17 @@
+import { expect, test } from '@jest/globals';
+import { generateEmptyPlayer } from '@/state';
+import { calculate, findResult, getMonster } from '@/tests/utils/TestUtils';
+import { DetailKey } from '@/lib/CalcDetails';
+
+test('Abyssal demon', () => {
+  const player = generateEmptyPlayer();
+  const monster = getMonster('Abyssal demon', 'Standard');
+  const { npcDefRoll, details } = calculate(player, monster);
+
+  expect(npcDefRoll).toBe(12096);
+  expect(findResult(details, DetailKey.DEFENCE_ROLL_LEVEL)).toBe(135);
+  expect(findResult(details, DetailKey.DEFENCE_ROLL_EFFECTIVE_LEVEL)).toBe(144);
+  expect(findResult(details, DetailKey.DEFENCE_ROLL_BASE)).toBe(12096);
+  expect(findResult(details, DetailKey.DEFENCE_ROLL_FINAL)).toBe(12096);
+  expect(findResult(details, DetailKey.DEFENCE_ROLL_TOA)).toBeUndefined();
+});

--- a/src/tests/utils/TestUtils.ts
+++ b/src/tests/utils/TestUtils.ts
@@ -2,6 +2,7 @@ import getMonsters from '@/lib/Monsters';
 import { Monster } from '@/types/Monster';
 import { Player } from '@/types/Player';
 import CombatCalc from '@/lib/CombatCalc';
+import { DetailEntry, DetailKey } from '@/lib/CalcDetails';
 
 const monsters = getMonsters();
 
@@ -16,13 +17,20 @@ export function getMonster(name: string, version: string): Monster {
 }
 
 export function calculate(player: Player, monster: Monster) {
-  const calc = new CombatCalc(player, monster);
-  const result = {
+  const calc = new CombatCalc(player, monster, {
+    loadoutName: 'test',
+    detailedOutput: true,
+  });
+  return {
     npcDefRoll: calc.getNPCDefenceRoll(),
     maxHit: calc.getDistribution().getMax(),
     maxAttackRoll: calc.getMaxAttackRoll(),
     accuracy: calc.getHitChance(),
     dps: calc.getDps(),
+    details: calc.details,
   };
-  return result;
+}
+
+export function findResult(details: DetailEntry[], key: DetailKey): number | undefined {
+  return details.find((d) => d.label === key)?.value;
 }

--- a/src/worker.ts
+++ b/src/worker.ts
@@ -26,7 +26,7 @@ const computeValues = async (loadouts: Player[], m: Monster, calcOpts: WorkerCal
   for (const [i, p] of loadouts.entries()) {
     const start = new Date().getTime();
     const calc = new CombatCalc(p, m, {
-      loadoutIx: i + 1,
+      loadoutName: `${i + 1}`,
     });
     res.push({
       npcDefRoll: calc.getNPCDefenceRoll(),


### PR DESCRIPTION
This adds a new opt-in subsystem to the calculator which can track intermediate results for recall later. We could eventually use this to complete #15, but for now it is being used to implement more specific tests.

I have not yet implemented this across the entire calculator, just to get some feedback on the setup first.

Pinging @SuperNerdEric @Nightfirecat for feedback as well.