### PR TITLE
canonicalize items in calc

### DIFF
--- a/src/app/components/player/equipment/EquipmentPresets.tsx
+++ b/src/app/components/player/equipment/EquipmentPresets.tsx
@@ -4,10 +4,10 @@ import EquipmentPreset from '@/enums/EquipmentPreset';
 import { useStore } from '@/state';
 import { PartialDeep } from 'type-fest';
 import { Player } from '@/types/Player';
+import { availableEquipment } from '@/lib/Equipment';
 
 const EquipmentPresets: React.FC = () => {
   const store = useStore();
-  const { availableEquipment } = store;
 
   const presets = [
     { label: 'Dharok\'s equipment', value: EquipmentPreset.DHAROKS },

--- a/src/app/components/player/equipment/EquipmentSelect.tsx
+++ b/src/app/components/player/equipment/EquipmentSelect.tsx
@@ -5,7 +5,7 @@ import { getCdnImage } from '@/utils';
 import { EquipmentPiece } from '@/types/Player';
 import LazyImage from '@/app/components/generic/LazyImage';
 import { cross } from 'd3-array';
-import { equipmentAliases } from '@/lib/Equipment';
+import { availableEquipment, equipmentAliases } from '@/lib/Equipment';
 import Combobox from '../../generic/Combobox';
 
 interface EquipmentOption {
@@ -41,7 +41,7 @@ const EquipmentSelect: React.FC = observer(() => {
     const dartEntries: EquipmentOption[] = [];
 
     const entries: EquipmentOption[] = [];
-    for (const v of store.availableEquipment) {
+    for (const v of availableEquipment) {
       const e: EquipmentOption = {
         label: `${v.name}`,
         value: v.id.toString(),
@@ -77,7 +77,7 @@ const EquipmentSelect: React.FC = observer(() => {
     });
 
     return entries;
-  }, [store.availableEquipment]);
+  }, []);
 
   return (
     <Combobox<EquipmentOption>

--- a/src/lib/Equipment.ts
+++ b/src/lib/Equipment.ts
@@ -1,10 +1,16 @@
-import { Player } from '@/types/Player';
+import { EquipmentPiece, Player } from '@/types/Player';
 import { Monster } from '@/types/Monster';
 import { keys } from '@/utils';
 import { TOMBS_OF_AMASCUT_MONSTER_IDS } from '@/lib/constants';
 import { sum } from 'd3-array';
+import equipment from '../../cdn/json/equipment.json';
 
 export type EquipmentBonuses = Pick<Player, 'bonuses' | 'offensive' | 'defensive'>;
+
+/**
+ * All available equipment that a player can equip.
+ */
+export const availableEquipment = equipment as EquipmentPiece[];
 
 const commonAmmoCategories = () => {
   const ret: { [k: string]: number[] } = {
@@ -374,6 +380,15 @@ export const getCanonicalItemId = (itemId: number): number => {
     if (v.includes(itemId)) return parseInt(k);
   }
   return itemId;
+};
+
+export const getCanonicalItem = (equipmentPiece: EquipmentPiece): EquipmentPiece => {
+  const canonicalId = getCanonicalItemId(equipmentPiece.id);
+  if (equipmentPiece.id === canonicalId) {
+    return equipmentPiece;
+  }
+
+  return availableEquipment.find((e) => e.id === canonicalId) || equipmentPiece;
 };
 
 export const calculateEquipmentBonusesFromGear = (player: Player, monster: Monster): EquipmentBonuses => {

--- a/src/types/State.ts
+++ b/src/types/State.ts
@@ -1,4 +1,4 @@
-import { EquipmentPiece, Player } from '@/types/Player';
+import { Player } from '@/types/Player';
 import { Monster } from '@/types/Monster';
 import UserIssueType from '@/enums/UserIssueType';
 import { DetailEntry } from '@/lib/CalcDetails';
@@ -77,11 +77,6 @@ export interface State extends ImportableData {
   prefs: Preferences;
   calc: Calculator;
   worker: Worker | null;
-
-  /**
-   * All available equipment that a player can equip.
-   */
-  availableEquipment: EquipmentPiece[];
 
   /**
    * All monsters that a player can fight.


### PR DESCRIPTION
Prevents desync issues from call-sites, notably the loadout comparison graph. To implement this I needed to move availableEquipment into a location accessible by the calc (out of global state). But, the availableEquipment doesn't change so it doesn't really need to be in global state anyway.