### PR TITLE
manual mode: don't recompute player stats automatically

### DIFF
--- a/src/state.tsx
+++ b/src/state.tsx
@@ -237,7 +237,11 @@ class GlobalState implements State {
     const equipmentTriggers: ((r: IReactionPublic) => unknown)[] = [
       () => toJS(this.monster),
     ];
-    equipmentTriggers.map((t) => reaction(t, this.recalculateEquipmentBonusesFromGearAll));
+    equipmentTriggers.map((t) => reaction(t, () => {
+      if (!this.prefs.manualMode) {
+        this.recalculateEquipmentBonusesFromGearAll();
+      }
+    }));
   }
 
   set debug(debug: boolean) {
@@ -507,8 +511,10 @@ class GlobalState implements State {
     }
 
     this.loadouts[loadoutIx] = merge(this.loadouts[loadoutIx], player);
-    if (eq || Object.hasOwn(player, 'spell')) {
-      this.recalculateEquipmentBonusesFromGear(loadoutIx);
+    if (!this.prefs.manualMode) {
+      if (eq || Object.hasOwn(player, 'spell')) {
+        this.recalculateEquipmentBonusesFromGear(loadoutIx);
+      }
     }
   }
 


### PR DESCRIPTION
we had this functionality before, but it was missed in the recalc-on-monster-change update for the shadow bonus

not sure at what point it was missed from equipment select as well, but this fixes it there too

closes #193