### PR TITLE
manual mode: fix unequal equipment bonus highlighting

### DIFF
--- a/src/app/components/player/Bonuses.tsx
+++ b/src/app/components/player/Bonuses.tsx
@@ -1,13 +1,19 @@
-import React from 'react';
+import React, { useMemo } from 'react';
 import { observer } from 'mobx-react-lite';
 import { useStore } from '@/state';
 import Offensive from '@/app/components/player/bonuses/Offensive';
 import Defensive from '@/app/components/player/bonuses/Defensive';
 import OtherBonuses from '@/app/components/player/bonuses/OtherBonuses';
+import { toJS } from 'mobx';
+import { calculateEquipmentBonusesFromGear } from '@/lib/Equipment';
 
 const Bonuses: React.FC = observer(() => {
   const store = useStore();
   const { manualMode } = store.prefs;
+
+  const player = toJS(store.player);
+  const monster = toJS(store.monster);
+  const computedStats = useMemo(() => calculateEquipmentBonusesFromGear(player, monster), [monster, player]);
 
   return (
     <div className="px-4 my-4">
@@ -21,9 +27,9 @@ const Bonuses: React.FC = observer(() => {
       </div>
       <div className="py-1">
         <div className="flex gap-4 justify-center">
-          <Offensive />
-          <Defensive />
-          <OtherBonuses />
+          <Offensive computedStats={computedStats} />
+          <Defensive computedStats={computedStats} />
+          <OtherBonuses computedStats={computedStats} />
         </div>
       </div>
     </div>

--- a/src/app/components/player/bonuses/Defensive.tsx
+++ b/src/app/components/player/bonuses/Defensive.tsx
@@ -7,10 +7,11 @@ import scimitar from '@/public/img/bonuses/scimitar.png';
 import warhammer from '@/public/img/bonuses/warhammer.png';
 import magic from '@/public/img/bonuses/magic.png';
 import ranged from '@/public/img/bonuses/ranged.png';
+import { EquipmentBonuses } from '@/lib/Equipment';
 
-const Defensive: React.FC = observer(() => {
+const Defensive: React.FC<{ computedStats: EquipmentBonuses }> = observer(({ computedStats }) => {
   const store = useStore();
-  const { prefs, player, equipmentBonuses } = store;
+  const { prefs, player } = store;
 
   return (
     <div className="w-[95px]">
@@ -21,7 +22,7 @@ const Defensive: React.FC = observer(() => {
           name="Stab"
           image={dagger}
           value={player.defensive.stab}
-          className={`${(player.defensive.stab !== equipmentBonuses.defensive.stab) ? 'bg-yellow-200 dark:bg-yellow-500' : ''}`}
+          className={`${(player.defensive.stab !== computedStats.defensive.stab) ? 'bg-yellow-200 dark:bg-yellow-500' : ''}`}
           onChange={(v) => store.updatePlayer({ defensive: { stab: v } })}
         />
         <AttributeInput
@@ -29,7 +30,7 @@ const Defensive: React.FC = observer(() => {
           name="Slash"
           image={scimitar}
           value={player.defensive.slash}
-          className={`${(player.defensive.slash !== equipmentBonuses.defensive.slash) ? 'bg-yellow-200 dark:bg-yellow-500' : ''}`}
+          className={`${(player.defensive.slash !== computedStats.defensive.slash) ? 'bg-yellow-200 dark:bg-yellow-500' : ''}`}
           onChange={(v) => store.updatePlayer({ defensive: { slash: v } })}
         />
         <AttributeInput
@@ -37,7 +38,7 @@ const Defensive: React.FC = observer(() => {
           name="Crush"
           image={warhammer}
           value={player.defensive.crush}
-          className={`${(player.defensive.crush !== equipmentBonuses.defensive.crush) ? 'bg-yellow-200 dark:bg-yellow-500' : ''}`}
+          className={`${(player.defensive.crush !== computedStats.defensive.crush) ? 'bg-yellow-200 dark:bg-yellow-500' : ''}`}
           onChange={(v) => store.updatePlayer({ defensive: { crush: v } })}
         />
         <AttributeInput
@@ -45,7 +46,7 @@ const Defensive: React.FC = observer(() => {
           name="Magic"
           image={magic}
           value={player.defensive.magic}
-          className={`${(player.defensive.magic !== equipmentBonuses.defensive.magic) ? 'bg-yellow-200 dark:bg-yellow-500' : ''}`}
+          className={`${(player.defensive.magic !== computedStats.defensive.magic) ? 'bg-yellow-200 dark:bg-yellow-500' : ''}`}
           onChange={(v) => store.updatePlayer({ defensive: { magic: v } })}
         />
         <AttributeInput
@@ -53,7 +54,7 @@ const Defensive: React.FC = observer(() => {
           name="Ranged"
           image={ranged}
           value={player.defensive.ranged}
-          className={`${(player.defensive.ranged !== equipmentBonuses.defensive.ranged) ? 'bg-yellow-200 dark:bg-yellow-500' : ''}`}
+          className={`${(player.defensive.ranged !== computedStats.defensive.ranged) ? 'bg-yellow-200 dark:bg-yellow-500' : ''}`}
           onChange={(v) => store.updatePlayer({ defensive: { ranged: v } })}
         />
       </div>

--- a/src/app/components/player/bonuses/Offensive.tsx
+++ b/src/app/components/player/bonuses/Offensive.tsx
@@ -7,10 +7,11 @@ import scimitar from '@/public/img/bonuses/scimitar.png';
 import warhammer from '@/public/img/bonuses/warhammer.png';
 import magic from '@/public/img/bonuses/magic.png';
 import ranged from '@/public/img/bonuses/ranged.png';
+import { EquipmentBonuses } from '@/lib/Equipment';
 
-const Offensive: React.FC = observer(() => {
+const Offensive: React.FC<{ computedStats: EquipmentBonuses }> = observer(({ computedStats }) => {
   const store = useStore();
-  const { prefs, player, equipmentBonuses } = store;
+  const { prefs, player } = store;
 
   return (
     <div className="w-[95px]">
@@ -21,7 +22,7 @@ const Offensive: React.FC = observer(() => {
           name="Stab"
           image={dagger}
           value={player.offensive.stab}
-          className={`${(player.offensive.stab !== equipmentBonuses.offensive.stab) ? 'bg-yellow-200 dark:bg-yellow-500' : ''}`}
+          className={`${(player.offensive.stab !== computedStats.offensive.stab) ? 'bg-yellow-200 dark:bg-yellow-500' : ''}`}
           onChange={(v) => store.updatePlayer({ offensive: { stab: v } })}
         />
         <AttributeInput
@@ -29,7 +30,7 @@ const Offensive: React.FC = observer(() => {
           name="Slash"
           image={scimitar}
           value={player.offensive.slash}
-          className={`${(player.offensive.slash !== equipmentBonuses.offensive.slash) ? 'bg-yellow-200 dark:bg-yellow-500' : ''}`}
+          className={`${(player.offensive.slash !== computedStats.offensive.slash) ? 'bg-yellow-200 dark:bg-yellow-500' : ''}`}
           onChange={(v) => store.updatePlayer({ offensive: { slash: v } })}
         />
         <AttributeInput
@@ -37,7 +38,7 @@ const Offensive: React.FC = observer(() => {
           name="Crush"
           image={warhammer}
           value={player.offensive.crush}
-          className={`${(player.offensive.crush !== equipmentBonuses.offensive.crush) ? 'bg-yellow-200 dark:bg-yellow-500' : ''}`}
+          className={`${(player.offensive.crush !== computedStats.offensive.crush) ? 'bg-yellow-200 dark:bg-yellow-500' : ''}`}
           onChange={(v) => store.updatePlayer({ offensive: { crush: v } })}
         />
         <AttributeInput
@@ -45,7 +46,7 @@ const Offensive: React.FC = observer(() => {
           name="Magic"
           image={magic}
           value={player.offensive.magic}
-          className={`${(player.offensive.magic !== equipmentBonuses.offensive.magic) ? 'bg-yellow-200 dark:bg-yellow-500' : ''}`}
+          className={`${(player.offensive.magic !== computedStats.offensive.magic) ? 'bg-yellow-200 dark:bg-yellow-500' : ''}`}
           onChange={(v) => store.updatePlayer({ offensive: { magic: v } })}
         />
         <AttributeInput
@@ -53,7 +54,7 @@ const Offensive: React.FC = observer(() => {
           name="Ranged"
           image={ranged}
           value={player.offensive.ranged}
-          className={`${(player.offensive.ranged !== equipmentBonuses.offensive.ranged) ? 'bg-yellow-200 dark:bg-yellow-500' : ''}`}
+          className={`${(player.offensive.ranged !== computedStats.offensive.ranged) ? 'bg-yellow-200 dark:bg-yellow-500' : ''}`}
           onChange={(v) => store.updatePlayer({ offensive: { ranged: v } })}
         />
       </div>

--- a/src/app/components/player/bonuses/OtherBonuses.tsx
+++ b/src/app/components/player/bonuses/OtherBonuses.tsx
@@ -6,10 +6,11 @@ import strength from '@/public/img/bonuses/strength.png';
 import rangedStrength from '@/public/img/bonuses/ranged_strength.png';
 import magicStrength from '@/public/img/bonuses/magic_strength.png';
 import prayer from '@/public/img/tabs/prayer.png';
+import { EquipmentBonuses } from '@/lib/Equipment';
 
-const OtherBonuses: React.FC = observer(() => {
+const OtherBonuses: React.FC<{ computedStats: EquipmentBonuses }> = observer(({ computedStats }) => {
   const store = useStore();
-  const { prefs, player, equipmentBonuses } = store;
+  const { prefs, player } = store;
 
   return (
     <div className="w-[95px]">
@@ -20,7 +21,7 @@ const OtherBonuses: React.FC = observer(() => {
           name="Strength"
           image={strength}
           value={player.bonuses.str}
-          className={`${(player.bonuses.str !== equipmentBonuses.bonuses.str) ? 'bg-yellow-200 dark:bg-yellow-500' : ''}`}
+          className={`${(player.bonuses.str !== computedStats.bonuses.str) ? 'bg-yellow-200 dark:bg-yellow-500' : ''}`}
           onChange={(v) => store.updatePlayer({ bonuses: { str: v } })}
         />
         <AttributeInput
@@ -28,7 +29,7 @@ const OtherBonuses: React.FC = observer(() => {
           name="Ranged Strength"
           image={rangedStrength}
           value={player.bonuses.ranged_str}
-          className={`${(player.bonuses.ranged_str !== equipmentBonuses.bonuses.ranged_str) ? 'bg-yellow-200 dark:bg-yellow-500' : ''}`}
+          className={`${(player.bonuses.ranged_str !== computedStats.bonuses.ranged_str) ? 'bg-yellow-200 dark:bg-yellow-500' : ''}`}
           onChange={(v) => store.updatePlayer({ bonuses: { ranged_str: v } })}
         />
         <AttributeInput
@@ -36,7 +37,7 @@ const OtherBonuses: React.FC = observer(() => {
           name="Magic Strength"
           image={magicStrength}
           value={player.bonuses.magic_str}
-          className={`${(player.bonuses.magic_str !== equipmentBonuses.bonuses.magic_str) ? 'bg-yellow-200 dark:bg-yellow-500' : ''}`}
+          className={`${(player.bonuses.magic_str !== computedStats.bonuses.magic_str) ? 'bg-yellow-200 dark:bg-yellow-500' : ''}`}
           onChange={(v) => store.updatePlayer({ bonuses: { magic_str: v } })}
         />
         <AttributeInput
@@ -44,7 +45,7 @@ const OtherBonuses: React.FC = observer(() => {
           name="Prayer"
           image={prayer}
           value={player.bonuses.prayer}
-          className={`${(player.bonuses.prayer !== equipmentBonuses.bonuses.prayer) ? 'bg-yellow-200 dark:bg-yellow-500' : ''}`}
+          className={`${(player.bonuses.prayer !== computedStats.bonuses.prayer) ? 'bg-yellow-200 dark:bg-yellow-500' : ''}`}
           onChange={(v) => store.updatePlayer({ bonuses: { prayer: v } })}
         />
       </div>

--- a/src/state.tsx
+++ b/src/state.tsx
@@ -24,10 +24,7 @@ import {
 import { RecomputeValuesRequest, WorkerRequestType } from '@/types/WorkerData';
 import { scaledMonster } from '@/lib/MonsterScaling';
 import getMonsters from '@/lib/Monsters';
-import {
-  calculateEquipmentBonusesFromGear,
-  EquipmentBonuses,
-} from '@/lib/Equipment';
+import { calculateEquipmentBonusesFromGear } from '@/lib/Equipment';
 import { EquipmentCategory } from './enums/EquipmentCategory';
 import {
   ARM_PRAYERS, BRAIN_PRAYERS, DEFENSIVE_PRAYERS, OFFENSIVE_PRAYERS, Prayer,
@@ -286,18 +283,6 @@ class GlobalState implements State {
     return getCombatStylesForCategory(cat);
   }
 
-  /**
-   * Return the player's worn equipment bonuses.
-   */
-  get equipmentBonuses(): EquipmentBonuses {
-    const p = this.player;
-    return {
-      bonuses: p.bonuses,
-      offensive: p.offensive,
-      defensive: p.defensive,
-    };
-  }
-
   recalculateEquipmentBonusesFromGear(loadoutIx?: number) {
     loadoutIx = loadoutIx !== undefined ? loadoutIx : this.selectedLoadout;
 
@@ -403,9 +388,7 @@ class GlobalState implements State {
 
     if (pref && Object.prototype.hasOwnProperty.call(pref, 'manualMode')) {
       // Reset player bonuses to their worn equipment
-      this.player.bonuses = this.equipmentBonuses.bonuses;
-      this.player.offensive = this.equipmentBonuses.offensive;
-      this.player.defensive = this.equipmentBonuses.defensive;
+      this.recalculateEquipmentBonusesFromGearAll();
     }
 
     // Save to browser storage


### PR DESCRIPTION
Another thing missed when the way we compute equipment stats was changed. `store.equipmentBonuses.{...}` now is always equal to `player.{...}`

Also, fixed the issue of leaving manual mode not recalculating stats. That was the last call-site of GlobalState's `equipmentBonuses`, so I've removed it altogether.