### PR TITLE
reset monster hp when switching monsters

### DIFF
--- a/src/app/components/monster/MonsterSelect.tsx
+++ b/src/app/components/monster/MonsterSelect.tsx
@@ -22,7 +22,6 @@ const MonsterSelect: React.FC = observer(() => {
     version: m.version || '',
     monster: {
       ...m,
-      monsterCurrentHp: m.skills.hp,
     },
   })), [availableMonsters]);
 

--- a/src/state.tsx
+++ b/src/state.tsx
@@ -239,6 +239,14 @@ class GlobalState implements State {
         this.recalculateEquipmentBonusesFromGearAll();
       }
     }));
+
+    // reset monster current hp when selecting a new monster
+    const monsterHpTriggers: ((r: IReactionPublic) => unknown)[] = [
+      () => toJS(this.monster.id),
+    ];
+    monsterHpTriggers.map((t) => reaction(t, () => {
+      this.monster.inputs.monsterCurrentHp = this.monster.skills.hp;
+    }));
   }
 
   set debug(debug: boolean) {


### PR DESCRIPTION
There is still a related but smaller bug with scaled monsters not setting to the correct value, but it's not new and I'm not sure how much extra work it would require (there's possible recursive concerns with watching monster.inputs).

closes #198
