### PR TITLE
Persist loadouts in local storage

### DIFF
--- a/src/app/home.tsx
+++ b/src/app/home.tsx
@@ -57,6 +57,7 @@ const Home: NextPage = observer(() => {
   useEffect(() => {
     // Load preferences from browser storage if there are any
     store.loadPreferences();
+    store.loadLoadouts();
 
     // Setup global event handling
     document.addEventListener('keydown', globalKeyDownHandler);

--- a/src/state.tsx
+++ b/src/state.tsx
@@ -440,6 +440,14 @@ class GlobalState implements State {
     this.selectedLoadout = data.selectedLoadout || 0;
   }
 
+  async loadLoadouts() {
+    const loadouts = await localforage.getItem<Player[]>('dps-calc-loadouts');
+
+    if (loadouts) {
+      this.loadouts = loadouts;
+    }
+  }
+
   loadPreferences() {
     localforage.getItem('dps-calc-prefs').then((v) => {
       this.updatePreferences(v as PartialDeep<Preferences>);
@@ -591,6 +599,8 @@ class GlobalState implements State {
         this.recalculateEquipmentBonusesFromGear(loadoutIx);
       }
     }
+
+    localforage.setItem('dps-calc-loadouts', toJS(this.loadouts));
   }
 
   /**


### PR DESCRIPTION
This PR would make loadouts persist in local storage as requested a few times (#185, #7 ). 

I know this issue was dismissed in the past but I think it would be worth revisiting. Personally I think its so easy to delete loadouts that most users would not mind if they persisted across sessions.  Re-entering a setup that was lost across sessions is a much larger hassle to users.

I would be interested in hearing other thoughts on the topic. 

Let me know if you would like me to change the implementation or add tests.