### PR TITLE
Fuzzy find search

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
     "axios": "^1.6.0",
     "d3-array": "^3.2.4",
     "downshift": "^8.3.1",
+    "fuzzbunny": "^1.0.1",
     "localforage": "^1.10.0",
     "lodash.isequal": "^4.5.0",
     "lodash.mergewith": "^4.6.2",

--- a/src/app/components/generic/Combobox.tsx
+++ b/src/app/components/generic/Combobox.tsx
@@ -60,7 +60,7 @@ const Combobox = <T extends ComboboxItem>(props: IComboboxProps<T>) => {
     if (value) setInputValue(value);
   }, [value]);
 
-  const preprocessedItems = useMemo(() => items.map((item) => ({ item, valueToFilter: `${item.label} ${item.version}` })), [items]);
+  const preprocessedItems = useMemo(() => items.map((item) => ({ item, valueToFilter: `${item.label} ${item.version ? item.version : ''}` })), [items]);
 
   const filteredItems = useMemo(() => {
     // When the input value changes, change the filtered items

--- a/src/app/components/generic/Combobox.tsx
+++ b/src/app/components/generic/Combobox.tsx
@@ -1,8 +1,9 @@
 import { useCombobox } from 'downshift';
+import { fuzzyFilter } from 'fuzzbunny';
 import React, { useEffect, useRef, useState } from 'react';
 import { Virtuoso, VirtuosoHandle } from 'react-virtuoso';
 
-type ComboboxItem = { label: string, value: string | number };
+type ComboboxItem = { label: string, version?: string, value: string | number };
 
 const itemToString = <T extends ComboboxItem>(i: T | null) => (i ? i.label : '');
 
@@ -63,7 +64,7 @@ const Combobox = <T extends ComboboxItem>(props: IComboboxProps<T>) => {
 
     // When the input value changes, change the filtered items
     if (inputValue) {
-      newFilteredItems = items.filter((v) => v.label.toLowerCase().includes(inputValue.toLowerCase()));
+      newFilteredItems = fuzzyFilter(items.map((item) => ({ item, valueToFilter: `${item.label} ${item.version}` })), inputValue, { fields: ['valueToFilter'] }).map((match) => match.item.item);
 
       if (customFilter !== undefined) {
         newFilteredItems = customFilter(newFilteredItems, inputValue);

--- a/yarn.lock
+++ b/yarn.lock
@@ -3650,6 +3650,13 @@ __metadata:
   languageName: node
   linkType: hard
 
+"fuzzbunny@npm:^1.0.1":
+  version: 1.0.1
+  resolution: "fuzzbunny@npm:1.0.1"
+  checksum: 427617fe9ae0ff54212a9fb1bced95b51b5e8d6642e9fd0c350168b97188e5f6beba25e6cd5a58f9017fcbc8be0886b5724eb956a708edde203adb1e9550d219
+  languageName: node
+  linkType: hard
+
 "gensync@npm:^1.0.0-beta.2":
   version: 1.0.0-beta.2
   resolution: "gensync@npm:1.0.0-beta.2"
@@ -5856,6 +5863,7 @@ __metadata:
     eslint-plugin-jsx-a11y: "npm:^6.8.0"
     eslint-plugin-react: "npm:^7.33.2"
     eslint-plugin-react-hooks: "npm:^4.6.0"
+    fuzzbunny: "npm:^1.0.1"
     jest: "npm:^29.7.0"
     jest-environment-jsdom: "npm:^29.7.0"
     localforage: "npm:^1.10.0"


### PR DESCRIPTION
Replace combobox substring filtering with something more [fuzzy](https://github.com/mixpanel/fuzzbunny#readme)! You can now filter by name and/or version. I tried out fuzzbunny and fuse.js, and fuzzbunny gave much more expected results. Here are some examples:
<img width="251" alt="image" src="https://github.com/weirdgloop/osrs-dps-calc/assets/2121068/08c9cdfc-ca0f-44f9-9e91-c21589ad1561">
<img width="251" alt="image" src="https://github.com/weirdgloop/osrs-dps-calc/assets/2121068/f4fb7246-f74a-4a7b-aca1-e1e0259f29f4">
<img width="249" alt="image" src="https://github.com/weirdgloop/osrs-dps-calc/assets/2121068/c1f27807-4299-4c54-ac0e-e377fa943cd0">
<img width="239" alt="image" src="https://github.com/weirdgloop/osrs-dps-calc/assets/2121068/66a06ec2-bef6-4ada-94e2-5639455dc6fe">
<img width="250" alt="image" src="https://github.com/weirdgloop/osrs-dps-calc/assets/2121068/645cb719-3fe8-4ae9-9b74-e9e8a05236ed">

My biggest complain is that fuzzbunny only allows matches to start at the beginning of words. This means if I miss a letter and search for "sythe" instead of "scythe", I get zero results.

