### PR TITLE
Filter equipment select based on slot selection

### DIFF
--- a/src/app/components/generic/Combobox.tsx
+++ b/src/app/components/generic/Combobox.tsx
@@ -14,6 +14,7 @@ interface IComboboxProps<T> {
   value?: string;
   items: T[];
   placeholder?: string;
+  inputRef?: React.MutableRefObject<HTMLInputElement | null>;
   onSelectedItemChange?: (item: T | null | undefined) => void;
   resetAfterSelect?: boolean;
   blurAfterSelect?: boolean;
@@ -39,6 +40,7 @@ const Combobox = <T extends ComboboxItem>(props: IComboboxProps<T>) => {
     id,
     value,
     items,
+    inputRef,
     onSelectedItemChange,
     resetAfterSelect,
     blurAfterSelect,
@@ -50,7 +52,7 @@ const Combobox = <T extends ComboboxItem>(props: IComboboxProps<T>) => {
     customFilter,
   } = props;
   const [inputValue, setInputValue] = useState<string>(value || '');
-  const inputRef = useRef<HTMLInputElement>(null);
+  const inputRefInternal = useRef<HTMLInputElement | null>(null);
   const menuRef = useRef<HTMLDivElement>(null);
   const virtuosoRef = useRef<VirtuosoHandle>(null);
   const [listHeight, setListHeight] = useState(200);
@@ -97,7 +99,7 @@ const Combobox = <T extends ComboboxItem>(props: IComboboxProps<T>) => {
     onSelectedItemChange: ({ selectedItem }) => {
       if (onSelectedItemChange) onSelectedItemChange(selectedItem);
       if (resetAfterSelect) reset();
-      if (blurAfterSelect) inputRef.current?.blur();
+      if (blurAfterSelect) inputRefInternal.current?.blur();
     },
     scrollIntoView: () => {},
     onHighlightedIndexChange: (changes) => {
@@ -148,13 +150,21 @@ const Combobox = <T extends ComboboxItem>(props: IComboboxProps<T>) => {
     },
   });
 
+  const combinedRef = (e: HTMLInputElement | null) => {
+    if (inputRef) {
+      inputRef.current = e;
+    }
+
+    inputRefInternal.current = e;
+  };
+
   return (
     <div>
       <input
         className={`form-control cursor-pointer ${className}`}
         // eslint-disable-next-line react/jsx-props-no-spreading
         {...getInputProps({
-          ref: inputRef, open: isOpen, type: 'text', placeholder: (placeholder || 'Search...'),
+          ref: combinedRef, open: isOpen, type: 'text', placeholder: (placeholder || 'Search...'),
         })}
       />
       <div

--- a/src/app/components/player/Equipment.tsx
+++ b/src/app/components/player/Equipment.tsx
@@ -9,6 +9,14 @@ const Equipment: React.FC = () => {
   const inputRef = useRef<HTMLInputElement>(null);
   const [slot, setSlot] = useState<EquipmentSlot | null>(null);
 
+  const updateSlot = (newSlot: EquipmentSlot) => {
+    if (newSlot === slot) {
+      setSlot(null);
+    } else {
+      setSlot(newSlot);
+    }
+  };
+
   useEffect(() => {
     if (slot) {
       inputRef.current?.focus();
@@ -18,11 +26,11 @@ const Equipment: React.FC = () => {
   return (
     <div className="px-4">
       <div className="mt-4">
-        <EquipmentGrid setSlot={setSlot} />
+        <EquipmentGrid selectedSlot={slot} setSlot={updateSlot} />
       </div>
       <div className="mt-4 flex grow gap-0.5">
         <div className="basis-full">
-          <EquipmentSelect slot={slot} inputRef={inputRef} />
+          <EquipmentSelect slot={slot} inputRef={inputRef} onSelect={() => setSlot(null)} />
         </div>
         <div className="basis-32">
           <EquipmentPresets />

--- a/src/app/components/player/Equipment.tsx
+++ b/src/app/components/player/Equipment.tsx
@@ -1,27 +1,39 @@
-import React from 'react';
+import React, { useEffect, useRef, useState } from 'react';
 import EquipmentGrid from '@/app/components/player/equipment/EquipmentGrid';
 import Bonuses from '@/app/components/player/Bonuses';
 import EquipmentPresets from '@/app/components/player/equipment/EquipmentPresets';
+import { EquipmentSlot } from '@/types/Player';
 import EquipmentSelect from './equipment/EquipmentSelect';
 
-const Equipment: React.FC = () => (
-  <div className="px-4">
-    <div className="mt-4">
-      <EquipmentGrid />
-    </div>
-    <div className="mt-4 flex grow gap-0.5">
-      <div className="basis-full">
-        <EquipmentSelect />
-      </div>
-      <div className="basis-32">
-        <EquipmentPresets />
-      </div>
-    </div>
-    <div>
-      <Bonuses />
-    </div>
-  </div>
+const Equipment: React.FC = () => {
+  const inputRef = useRef<HTMLInputElement>(null);
+  const [slot, setSlot] = useState<EquipmentSlot | null>(null);
 
-);
+  useEffect(() => {
+    if (slot) {
+      inputRef.current?.focus();
+    }
+  }, [slot]);
+
+  return (
+    <div className="px-4">
+      <div className="mt-4">
+        <EquipmentGrid setSlot={setSlot} />
+      </div>
+      <div className="mt-4 flex grow gap-0.5">
+        <div className="basis-full">
+          <EquipmentSelect slot={slot} inputRef={inputRef} />
+        </div>
+        <div className="basis-32">
+          <EquipmentPresets />
+        </div>
+      </div>
+      <div>
+        <Bonuses />
+      </div>
+    </div>
+
+  );
+};
 
 export default Equipment;

--- a/src/app/components/player/equipment/EquipmentGrid.tsx
+++ b/src/app/components/player/equipment/EquipmentGrid.tsx
@@ -14,31 +14,32 @@ import EquipmentGridSlot from '@/app/components/player/equipment/EquipmentGridSl
 import { EquipmentSlot } from '@/types/Player';
 
 interface EquipmentGridProps {
+  selectedSlot: EquipmentSlot | null;
   setSlot: (slot: EquipmentSlot) => void
 }
 
-const EquipmentGrid: React.FC<EquipmentGridProps> = ({ setSlot }) => (
+const EquipmentGrid: React.FC<EquipmentGridProps> = ({ selectedSlot, setSlot }) => (
   <>
     <div className="flex justify-center">
-      <EquipmentGridSlot slot="head" placeholder={head.src} onClick={setSlot} />
+      <EquipmentGridSlot slot="head" selected={selectedSlot === 'head'} placeholder={head.src} onClick={setSlot} />
     </div>
     <div className="mt-1 flex justify-center gap-2">
-      <EquipmentGridSlot slot="cape" placeholder={cape.src} onClick={setSlot} />
-      <EquipmentGridSlot slot="neck" placeholder={neck.src} onClick={setSlot} />
-      <EquipmentGridSlot slot="ammo" placeholder={ammo.src} onClick={setSlot} />
+      <EquipmentGridSlot slot="cape" selected={selectedSlot === 'cape'} placeholder={cape.src} onClick={setSlot} />
+      <EquipmentGridSlot slot="neck" selected={selectedSlot === 'neck'} placeholder={neck.src} onClick={setSlot} />
+      <EquipmentGridSlot slot="ammo" selected={selectedSlot === 'ammo'} placeholder={ammo.src} onClick={setSlot} />
     </div>
     <div className="mt-1 flex justify-center gap-6">
-      <EquipmentGridSlot slot="weapon" placeholder={weapon.src} onClick={setSlot} />
-      <EquipmentGridSlot slot="body" placeholder={body.src} onClick={setSlot} />
-      <EquipmentGridSlot slot="shield" placeholder={shield.src} onClick={setSlot} />
+      <EquipmentGridSlot slot="weapon" selected={selectedSlot === 'weapon'} placeholder={weapon.src} onClick={setSlot} />
+      <EquipmentGridSlot slot="body" selected={selectedSlot === 'body'} placeholder={body.src} onClick={setSlot} />
+      <EquipmentGridSlot slot="shield" selected={selectedSlot === 'shield'} placeholder={shield.src} onClick={setSlot} />
     </div>
     <div className="mt-1 flex justify-center">
-      <EquipmentGridSlot slot="legs" placeholder={legs.src} onClick={setSlot} />
+      <EquipmentGridSlot slot="legs" selected={selectedSlot === 'legs'} placeholder={legs.src} onClick={setSlot} />
     </div>
     <div className="mt-1 flex justify-center gap-6">
-      <EquipmentGridSlot slot="hands" placeholder={hands.src} onClick={setSlot} />
-      <EquipmentGridSlot slot="feet" placeholder={feet.src} onClick={setSlot} />
-      <EquipmentGridSlot slot="ring" placeholder={ring.src} onClick={setSlot} />
+      <EquipmentGridSlot slot="hands" selected={selectedSlot === 'hands'} placeholder={hands.src} onClick={setSlot} />
+      <EquipmentGridSlot slot="feet" selected={selectedSlot === 'feet'} placeholder={feet.src} onClick={setSlot} />
+      <EquipmentGridSlot slot="ring" selected={selectedSlot === 'ring'} placeholder={ring.src} onClick={setSlot} />
     </div>
   </>
 );

--- a/src/app/components/player/equipment/EquipmentGrid.tsx
+++ b/src/app/components/player/equipment/EquipmentGrid.tsx
@@ -11,29 +11,34 @@ import hands from '@/public/img/slots/hands.png';
 import feet from '@/public/img/slots/feet.png';
 import ring from '@/public/img/slots/ring.png';
 import EquipmentGridSlot from '@/app/components/player/equipment/EquipmentGridSlot';
+import { EquipmentSlot } from '@/types/Player';
 
-const EquipmentGrid: React.FC = () => (
+interface EquipmentGridProps {
+  setSlot: (slot: EquipmentSlot) => void
+}
+
+const EquipmentGrid: React.FC<EquipmentGridProps> = ({ setSlot }) => (
   <>
     <div className="flex justify-center">
-      <EquipmentGridSlot slot="head" placeholder={head.src} />
+      <EquipmentGridSlot slot="head" placeholder={head.src} onClick={setSlot} />
     </div>
     <div className="mt-1 flex justify-center gap-2">
-      <EquipmentGridSlot slot="cape" placeholder={cape.src} />
-      <EquipmentGridSlot slot="neck" placeholder={neck.src} />
-      <EquipmentGridSlot slot="ammo" placeholder={ammo.src} />
+      <EquipmentGridSlot slot="cape" placeholder={cape.src} onClick={setSlot} />
+      <EquipmentGridSlot slot="neck" placeholder={neck.src} onClick={setSlot} />
+      <EquipmentGridSlot slot="ammo" placeholder={ammo.src} onClick={setSlot} />
     </div>
     <div className="mt-1 flex justify-center gap-6">
-      <EquipmentGridSlot slot="weapon" placeholder={weapon.src} />
-      <EquipmentGridSlot slot="body" placeholder={body.src} />
-      <EquipmentGridSlot slot="shield" placeholder={shield.src} />
+      <EquipmentGridSlot slot="weapon" placeholder={weapon.src} onClick={setSlot} />
+      <EquipmentGridSlot slot="body" placeholder={body.src} onClick={setSlot} />
+      <EquipmentGridSlot slot="shield" placeholder={shield.src} onClick={setSlot} />
     </div>
     <div className="mt-1 flex justify-center">
-      <EquipmentGridSlot slot="legs" placeholder={legs.src} />
+      <EquipmentGridSlot slot="legs" placeholder={legs.src} onClick={setSlot} />
     </div>
     <div className="mt-1 flex justify-center gap-6">
-      <EquipmentGridSlot slot="hands" placeholder={hands.src} />
-      <EquipmentGridSlot slot="feet" placeholder={feet.src} />
-      <EquipmentGridSlot slot="ring" placeholder={ring.src} />
+      <EquipmentGridSlot slot="hands" placeholder={hands.src} onClick={setSlot} />
+      <EquipmentGridSlot slot="feet" placeholder={feet.src} onClick={setSlot} />
+      <EquipmentGridSlot slot="ring" placeholder={ring.src} onClick={setSlot} />
     </div>
   </>
 );

--- a/src/app/components/player/equipment/EquipmentGridSlot.tsx
+++ b/src/app/components/player/equipment/EquipmentGridSlot.tsx
@@ -1,4 +1,4 @@
-import { PlayerEquipment } from '@/types/Player';
+import { EquipmentSlot } from '@/types/Player';
 import React, { useMemo } from 'react';
 import { observer } from 'mobx-react-lite';
 import { useStore } from '@/state';
@@ -6,18 +6,27 @@ import { getCdnImage } from '@/utils';
 import UserIssueWarning from '@/app/components/generic/UserIssueWarning';
 
 interface EquipmentGridSlotProps {
-  slot: keyof PlayerEquipment;
+  slot: EquipmentSlot;
   placeholder?: string;
+  onClick: (slot: EquipmentSlot) => void;
 }
 
 const EquipmentGridSlot: React.FC<EquipmentGridSlotProps> = observer((props) => {
   const store = useStore();
-  const { slot, placeholder } = props;
+  const { slot, placeholder, onClick } = props;
   const currentSlot = store.equipmentData[slot];
   const isEmpty = !currentSlot;
 
   // Determine whether there's any issues with this element
   const issues = useMemo(() => store.userIssues.filter((i) => i.type.startsWith(`equipment_slot_${slot}`) && i.loadout === `${store.selectedLoadout + 1}`), [store.userIssues, store.selectedLoadout, slot]);
+
+  const onClickHandler = () => {
+    if (isEmpty) {
+      onClick(slot);
+    } else {
+      store.clearEquipmentSlot(slot);
+    }
+  };
 
   return (
     <div className="h-[40px] w-[40px] relative">
@@ -32,9 +41,7 @@ const EquipmentGridSlot: React.FC<EquipmentGridSlotProps> = observer((props) => 
         data-slot={slot}
         data-tooltip-id="tooltip"
         data-tooltip-content={currentSlot?.name}
-        onMouseDown={() => {
-          if (!isEmpty) store.clearEquipmentSlot(slot);
-        }}
+        onClick={onClickHandler}
       >
         {currentSlot?.image ? (
           <img src={getCdnImage(`equipment/${currentSlot.image}`)} alt={currentSlot.name} />

--- a/src/app/components/player/equipment/EquipmentGridSlot.tsx
+++ b/src/app/components/player/equipment/EquipmentGridSlot.tsx
@@ -8,12 +8,15 @@ import UserIssueWarning from '@/app/components/generic/UserIssueWarning';
 interface EquipmentGridSlotProps {
   slot: EquipmentSlot;
   placeholder?: string;
+  selected: boolean;
   onClick: (slot: EquipmentSlot) => void;
 }
 
 const EquipmentGridSlot: React.FC<EquipmentGridSlotProps> = observer((props) => {
   const store = useStore();
-  const { slot, placeholder, onClick } = props;
+  const {
+    slot, placeholder, selected, onClick,
+  } = props;
   const currentSlot = store.equipmentData[slot];
   const isEmpty = !currentSlot;
 
@@ -37,7 +40,7 @@ const EquipmentGridSlot: React.FC<EquipmentGridSlotProps> = observer((props) => 
       }
       <button
         type="button"
-        className={`flex justify-center items-center h-[40px] w-[40px] bg-body-100 dark:bg-dark-400 dark:border-dark-400 border border-body-300 transition-colors rounded ${!isEmpty ? 'cursor-pointer hover:border-red' : ''}`}
+        className={`flex justify-center items-center h-[40px] w-[40px] bg-body-100 dark:bg-dark-400 border transition-colors rounded ${!isEmpty ? 'cursor-pointer hover:border-red-500' : ''} ${selected ? 'border-blue-600' : 'dark:border-dark-400 border-body-300'}`}
         data-slot={slot}
         data-tooltip-id="tooltip"
         data-tooltip-content={currentSlot?.name}

--- a/src/app/components/player/equipment/EquipmentSelect.tsx
+++ b/src/app/components/player/equipment/EquipmentSelect.tsx
@@ -2,7 +2,7 @@ import React, { useMemo } from 'react';
 import { useStore } from '@/state';
 import { observer } from 'mobx-react-lite';
 import { getCdnImage } from '@/utils';
-import { EquipmentPiece } from '@/types/Player';
+import { EquipmentPiece, EquipmentSlot } from '@/types/Player';
 import LazyImage from '@/app/components/generic/LazyImage';
 import { cross } from 'd3-array';
 import { availableEquipment, equipmentAliases } from '@/lib/Equipment';
@@ -14,6 +14,11 @@ interface EquipmentOption {
   version: string;
   slot: string;
   equipment: EquipmentPiece;
+}
+
+interface EquipmentSelectProps {
+  slot: EquipmentSlot | null;
+  inputRef: React.MutableRefObject<HTMLInputElement | null>;
 }
 
 const BLOWPIPE_IDS: string[] = [
@@ -33,7 +38,7 @@ const DART_IDS: string[] = [
   '25849', // amethyst
 ];
 
-const EquipmentSelect: React.FC = observer(() => {
+const EquipmentSelect: React.FC<EquipmentSelectProps> = observer(({ slot, inputRef }) => {
   const store = useStore();
 
   const options: EquipmentOption[] = useMemo(() => {
@@ -84,6 +89,7 @@ const EquipmentSelect: React.FC = observer(() => {
       id="equipment-select"
       className="w-full"
       items={options}
+      inputRef={inputRef}
       keepOpenAfterSelect
       keepPositionAfterSelect
       placeholder="Search for equipment..."
@@ -127,6 +133,7 @@ const EquipmentSelect: React.FC = observer(() => {
         }
 
         return v.filter((eqOpt) => {
+          if (slot && eqOpt.slot !== slot) return false;
           const eqId = eqOpt.equipment.id;
 
           // This is a base variant, keep it in the list

--- a/src/app/components/player/equipment/EquipmentSelect.tsx
+++ b/src/app/components/player/equipment/EquipmentSelect.tsx
@@ -19,6 +19,7 @@ interface EquipmentOption {
 interface EquipmentSelectProps {
   slot: EquipmentSlot | null;
   inputRef: React.MutableRefObject<HTMLInputElement | null>;
+  onSelect: () => void;
 }
 
 const BLOWPIPE_IDS: string[] = [
@@ -38,7 +39,7 @@ const DART_IDS: string[] = [
   '25849', // amethyst
 ];
 
-const EquipmentSelect: React.FC<EquipmentSelectProps> = observer(({ slot, inputRef }) => {
+const EquipmentSelect: React.FC<EquipmentSelectProps> = observer(({ slot, inputRef, onSelect }) => {
   const store = useStore();
 
   const options: EquipmentOption[] = useMemo(() => {
@@ -90,11 +91,11 @@ const EquipmentSelect: React.FC<EquipmentSelectProps> = observer(({ slot, inputR
       className="w-full"
       items={options}
       inputRef={inputRef}
-      keepOpenAfterSelect
-      keepPositionAfterSelect
+      resetAfterSelect
       placeholder="Search for equipment..."
       onSelectedItemChange={(item) => {
         if (item) {
+          onSelect();
           store.updatePlayer({
             equipment: {
               [item.equipment.slot]: item.equipment,

--- a/src/types/Player.ts
+++ b/src/types/Player.ts
@@ -44,6 +44,8 @@ export interface PlayerEquipment {
   ring: EquipmentPiece | null;
 }
 
+export type EquipmentSlot = keyof PlayerEquipment;
+
 export interface PlayerBonuses {
   str: number;
   ranged_str: number;


### PR DESCRIPTION
This pull requests adds the ability to click on an equipment slot to narrow down the list of equipment in the dropdown. This is more in line with how people would have used the DPS spreadsheets to enter in equipment and something I think a lot of users would like.

Before
![image](https://github.com/weirdgloop/osrs-dps-calc/assets/24963830/37b2fa0a-e77f-4783-a342-6c8d2e2bc7fd)

After
![image](https://github.com/weirdgloop/osrs-dps-calc/assets/24963830/ba46817e-12eb-4dca-aa24-8c86d1a4c9b7)


This was also a highly requested feature from the original Reddit post.

> i'd love to see some sort of implementation to click on a slot to focus the search on items for that slot -- can get a little annoying trying to add something like god d'hide and seeing all equipable saradomin items ever pop up in the search <sup>[1](https://www.reddit.com/r/2007scape/comments/1adam6c/osrs_wiki_has_a_dps_calculator_now_go_check_it_out/kk1ur69/) </sup>

>  ...it would be nice if you could click on a gear slot to limit to the search to that slot. <sup>[2](https://www.reddit.com/r/2007scape/comments/1adam6c/osrs_wiki_has_a_dps_calculator_now_go_check_it_out/kjzvek7/) </sup>

> One thing I wish would come to this is what the dps page I use, uses, where you click the slot and it automatically takes you to the search box and you can only search items of that category <sup>[3](https://www.reddit.com/r/2007scape/comments/1adam6c/osrs_wiki_has_a_dps_calculator_now_go_check_it_out/kk11vpm/) </sup>

> i think it would be better to select equipment by slot instead of just having one search bar for everything <sup>[4](https://www.reddit.com/r/2007scape/comments/1adam6c/osrs_wiki_has_a_dps_calculator_now_go_check_it_out/kobuguo/) </sup>

Let me know if you would like me to change anything!