### PR TITLE
remove monster current hp max hit limiter

### DIFF
--- a/src/lib/PlayerVsNPCCalc.ts
+++ b/src/lib/PlayerVsNPCCalc.ts
@@ -748,11 +748,11 @@ export default class PlayerVsNPCCalc extends BaseCalc {
 
     if (style === 'ranged' && this.isWearingKarils()) {
       dist = new AttackDistribution([
-        standardHitDist.scaleProbability(0.75),
         new HitDistribution([
+          ...standardHitDist.scaleProbability(0.75).hits,
           ...standardHitDist.hits.map((h) => new WeightedHit(
-            h.probability * 0.25, // 25% chance to
-            [...h.hitsplats, ...h.hitsplats.map((s) => Math.trunc(s / 2))], // deal a second hitsplat of half damage
+            h.probability * 0.25, // 25% chance of effect
+            [h.hitsplats[0], Math.trunc(h.hitsplats[0] / 2)], // to deal a second hitsplat of half damage
           )),
         ]),
       ]);

--- a/src/lib/PlayerVsNPCCalc.ts
+++ b/src/lib/PlayerVsNPCCalc.ts
@@ -957,9 +957,6 @@ export default class PlayerVsNPCCalc extends BaseCalc {
       }
     }
 
-    // now also cap hits indiscriminately by the monster's max health, in case it is higher
-    dist = dist.transform(flatLimitTransformer(this.monster.skills.hp));
-
     return dist;
   }
 


### PR DESCRIPTION
this was causing some issues with probabilities being lost on hit transformers, and also messed with expected hit calculations in low-hp scenarios