### PR TITLE
prevent double render of annotations

### DIFF
--- a/src/app/components/results/LoadoutComparison.tsx
+++ b/src/app/components/results/LoadoutComparison.tsx
@@ -199,7 +199,7 @@ const LoadoutComparison: React.FC = observer(() => {
 
     return [
       ...compareResult.annotations.x.map((a) => toRecharts(a, true)),
-      ...compareResult.annotations.x.map((a) => toRecharts(a, false)),
+      ...compareResult.annotations.y.map((a) => toRecharts(a, false)),
     ];
   }, [compareResult, isDark]);
 


### PR DESCRIPTION
this was causing the DWH annotations to render twice, with duplicate react component keys, breaking the renderer and permanently getting them stuck on screen