### PR TITLE
fix stat decay x axis not changing

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -22,6 +22,8 @@ import SuperDefence from '@/public/img/potions/Super defence.png';
 import Potion from '@/enums/Potion';
 import { EquipmentCategory } from '@/enums/EquipmentCategory';
 import { PlayerCombatStyle } from '@/types/PlayerCombatStyle';
+import { PartialDeep } from 'type-fest';
+import merge from 'lodash.mergewith';
 
 export const classNames = (...classes: string[]) => classes.filter(Boolean).join(' ');
 
@@ -91,6 +93,8 @@ export const getCdnImage = (filename: string) => `https://tools.runescape.wiki/o
 export const isDevServer = () => process.env.NODE_ENV === 'development';
 
 export const keys = <T extends object>(o: T): (keyof T)[] => Object.keys(o) as (keyof T)[];
+
+export const typedMerge = <T, E extends PartialDeep<T>>(base: T, updates: E): T => merge({}, base, updates);
 
 export class DeferredPromise<T> {
   private _resolve!: (response: T) => void;


### PR DESCRIPTION
Two issues here:
* The result of `merge(player, playerBoosts)` is not a valid player. It should have been `merge(player, { boosts: playerBoosts })`.
* Also, it turns out `_.merge` default mutates the source object, which caused the decay to apply back to the `baseLoadouts`.

I took the opportunity to also move `typedMerge` into utils, and make the boosts x axis generator more verbose, but also more intuitively legible.