### PR TITLE
load stance correctly on shortlink

### DIFF
--- a/src/state.tsx
+++ b/src/state.tsx
@@ -564,7 +564,7 @@ class GlobalState implements State {
       if (newWeapon !== undefined) {
         const oldWeaponCat = currentWeapon?.category || EquipmentCategory.NONE;
         const newWeaponCat = newWeapon?.category || EquipmentCategory.NONE;
-        if ((newWeaponCat !== undefined) && (newWeaponCat !== oldWeaponCat)) {
+        if ((newWeaponCat !== undefined) && (newWeaponCat !== oldWeaponCat) && !player.style) {
           // If the weapon slot category was changed, we should reset the player's selected combat style to the first one that exists.
           player.style = getCombatStylesForCategory(newWeaponCat)[0];
         }


### PR DESCRIPTION
If the weapon loaded from the shortlink is not an UNARMED weapon (which is most), we were seeing that the style had changed, and resetting the options. We should not do this when the update call includes a style, and instead use the style provided.