### PR TITLE
Update Max Ranged Preset to Use Blessed Dizana's Quiver

### DIFF
--- a/src/app/components/player/equipment/EquipmentPresets.tsx
+++ b/src/app/components/player/equipment/EquipmentPresets.tsx
@@ -90,7 +90,7 @@ const EquipmentPresets: React.FC = () => {
           name: v.label,
           equipment: {
             head: findItemById(27235), // Masori mask (f)
-            cape: findItemById(22109), // Ava's assembler
+            cape: findItemById(28955), // Blessed dizana's quiver
             neck: findItemById(19547), // Necklace of anguish
             ammo: findItemById(11212), // Dragon arrow
             body: findItemById(27238), // Masori body (f)


### PR DESCRIPTION
This PR updates the Max Ranged Preset to use the new Blessed Dizana's Quiver. While testing I realized that the DPS calc does not handle the conditional increase from the blessed version of the quiver, instead treating the blessed quiver as if it has the same stats as the unblessed version even if the setup is using arrows from the quiver.

I can look into implementing the quiver's conditional bonuses if needed as well.

Doing a bit more digging, I noticed that `cdn/json/equipment.json` and `cdn/json/monsters.json` were updated while I initialized the project locally. Both the blessed version of the quiver and the max cape version were changed from having the buffed conditional stats back to the base, non-buffed stats. I confirmed that the stats are incorrect in production, so I'm not sure why the stats that are checked into the `staging` branch are not appearing in prod.