### PR TITLE
Dizana's quiver bonus

### DIFF
--- a/src/lib/Equipment.ts
+++ b/src/lib/Equipment.ts
@@ -293,5 +293,13 @@ export const calculateEquipmentBonusesFromGear = (player: Player, monster: Monst
     totals.bonuses.magic_str += 3 * virtusPieces;
   }
 
+  const cape = playerEquipment.cape;
+  const dizanasQuiverCharged = cape?.name === "Blessed dizana's quiver"
+    || (cape?.name === "Dizana's quiver" && cape?.version === 'Charged');
+  if (dizanasQuiverCharged && ammoApplicability(player.equipment.weapon?.id, player.equipment.ammo?.id) === AmmoApplicability.INCLUDED) {
+    totals.offensive.ranged += 10;
+    totals.bonuses.ranged_str += 1;
+  }
+
   return totals;
 };

--- a/src/tests/lib/Equipment.test.ts
+++ b/src/tests/lib/Equipment.test.ts
@@ -1,0 +1,121 @@
+import { findEquipment, getTestMonster, getTestPlayer } from '@/tests/utils/TestUtils';
+import { describe, expect, test } from '@jest/globals';
+import { calculateEquipmentBonusesFromGear } from '@/lib/Equipment';
+
+describe('calculateEquipmentBonusesFromGear', () => {
+  describe("with Dizana's quiver", () => {
+    describe('with weapon using ammo slot', () => {
+      test('applies bonus when charged', () => {
+        const monster = getTestMonster('Abyssal demon', 'Standard');
+        const playerWithChargedQuiver = getTestPlayer(monster, {
+          equipment: {
+            cape: findEquipment("Dizana's quiver", 'Charged'),
+            weapon: findEquipment('Twisted bow'),
+            ammo: findEquipment('Dragon arrow', 'Unpoisoned'),
+          },
+        });
+
+        const bonuses = calculateEquipmentBonusesFromGear(playerWithChargedQuiver, monster);
+        expect(bonuses.offensive.ranged).toStrictEqual(98);
+        expect(bonuses.bonuses.ranged_str).toStrictEqual(84);
+      });
+
+      test('applies bonus when blessed', () => {
+        const monster = getTestMonster('Abyssal demon', 'Standard');
+        const playerWithChargedQuiver = getTestPlayer(monster, {
+          equipment: {
+            cape: findEquipment("Blessed dizana's quiver", 'Normal'),
+            weapon: findEquipment('Twisted bow'),
+            ammo: findEquipment('Dragon arrow', 'Unpoisoned'),
+          },
+          offensive: {
+            ranged: 0,
+          },
+          bonuses: {
+            ranged_str: 0,
+          },
+        });
+
+        const bonuses = calculateEquipmentBonusesFromGear(playerWithChargedQuiver, monster);
+        expect(bonuses.offensive.ranged).toStrictEqual(98);
+        expect(bonuses.bonuses.ranged_str).toStrictEqual(84);
+      });
+
+      test('does not apply bonus when uncharged', () => {
+        const monster = getTestMonster('Abyssal demon', 'Standard');
+        const playerWithChargedQuiver = getTestPlayer(monster, {
+          equipment: {
+            cape: findEquipment("Dizana's quiver", 'Uncharged'),
+            weapon: findEquipment('Twisted bow'),
+            ammo: findEquipment('Dragon arrow', 'Unpoisoned'),
+          },
+          offensive: {
+            ranged: 0,
+          },
+          bonuses: {
+            ranged_str: 0,
+          },
+        });
+
+        const bonuses = calculateEquipmentBonusesFromGear(playerWithChargedQuiver, monster);
+        expect(bonuses.offensive.ranged).toStrictEqual(88);
+        expect(bonuses.bonuses.ranged_str).toStrictEqual(83);
+      });
+    });
+    describe('with weapon not using ammo slot', () => {
+      test('does not apply bonus when charged', () => {
+        const monster = getTestMonster('Abyssal demon', 'Standard');
+        const playerWithChargedQuiver = getTestPlayer(monster, {
+          equipment: {
+            cape: findEquipment("Dizana's quiver", 'Charged'),
+            weapon: findEquipment('Dragon dart'),
+          },
+        });
+
+        const bonuses = calculateEquipmentBonusesFromGear(playerWithChargedQuiver, monster);
+        expect(bonuses.offensive.ranged).toStrictEqual(18);
+        expect(bonuses.bonuses.ranged_str).toStrictEqual(38);
+      });
+
+      test('does not apply bonus when blessed', () => {
+        const monster = getTestMonster('Abyssal demon', 'Standard');
+        const playerWithChargedQuiver = getTestPlayer(monster, {
+          equipment: {
+            cape: findEquipment("Blessed dizana's quiver", 'Normal'),
+            weapon: findEquipment('Dragon dart'),
+          },
+          offensive: {
+            ranged: 0,
+          },
+          bonuses: {
+            ranged_str: 0,
+          },
+        });
+
+        const bonuses = calculateEquipmentBonusesFromGear(playerWithChargedQuiver, monster);
+        expect(bonuses.offensive.ranged).toStrictEqual(18);
+        expect(bonuses.bonuses.ranged_str).toStrictEqual(38);
+      });
+
+      test('does not apply bonus when uncharged', () => {
+        const monster = getTestMonster('Abyssal demon', 'Standard');
+        const playerWithChargedQuiver = getTestPlayer(monster, {
+          equipment: {
+            cape: findEquipment("Dizana's quiver", 'Uncharged'),
+            weapon: findEquipment('Dragon dart'),
+          },
+          offensive: {
+            ranged: 0,
+          },
+          bonuses: {
+            ranged_str: 0,
+          },
+        });
+
+        const bonuses = calculateEquipmentBonusesFromGear(playerWithChargedQuiver, monster);
+        expect(bonuses.offensive.ranged).toStrictEqual(18);
+        expect(bonuses.bonuses.ranged_str).toStrictEqual(38);
+      });
+    });
+  });
+});


### PR DESCRIPTION
It is implemented as a visible bonus in-game, so we do the same here. Ammo can be pulled from either ammo slot and still receive the bonus, so we do not need to distinguish between the two. Weapons not using ammo slots (thrown, chinchompa, etc) do not receive the bonus.