### PR TITLE
Persist browser session

### DIFF
--- a/src/app/components/InitialLoad.tsx
+++ b/src/app/components/InitialLoad.tsx
@@ -4,6 +4,7 @@ import { useSearchParams } from 'next/navigation';
 import localforage from 'localforage';
 import { observer } from 'mobx-react-lite';
 import { ImportableData } from '@/types/State';
+import { toast } from 'react-toastify';
 
 /**
  * This is a dummy component that is rendered inside a Suspense boundary in home.tsx. This is so that we have access to
@@ -28,6 +29,7 @@ const InitialLoad: React.FC = observer(() => {
         try {
           const state = await localforage.getItem('dps-calc-state');
           store.updateImportedData(state as ImportableData);
+          toast.success('Restored last browser session', { toastId: 'state-restore' });
         } catch (e) {
           // If state couldn't be loaded (or there wasn't any), then try to load the username and lookup stats, at least
           try {

--- a/src/app/components/InitialLoad.tsx
+++ b/src/app/components/InitialLoad.tsx
@@ -58,11 +58,6 @@ const InitialLoad: React.FC = observer(() => {
 
     if (loaded) return;
     doFirstLoad();
-
-    // This code is necessary because searchParams may change later, when we strip the query params from the URL
-    if (loaded) return;
-    setLoaded(true);
-
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [searchParams]);
 

--- a/src/app/components/InitialLoad.tsx
+++ b/src/app/components/InitialLoad.tsx
@@ -39,7 +39,8 @@ const InitialLoad: React.FC = observer(() => {
             store.updateUIState({ username: u as string });
             if (u) store.fetchCurrentPlayerSkills();
           })
-          .catch(() => {}));
+          .catch(() => {})
+          .finally(() => store.startStorageUpdater()));
     }
 
     const monster = searchParams.get('monster');

--- a/src/app/components/InitialLoad.tsx
+++ b/src/app/components/InitialLoad.tsx
@@ -17,40 +17,50 @@ const InitialLoad: React.FC = observer(() => {
   const [loaded, setLoaded] = useState(false);
 
   useEffect(() => {
+    const doFirstLoad = async () => {
+      const id = searchParams.get('id');
+      if (id) {
+        // If there was a share ID provided, load the data for it into the calculator
+        await store.loadShortlink(id);
+        window.history.replaceState({}, '', process.env.NEXT_PUBLIC_BASE_PATH);
+      } else {
+        // Else, try to load any previously saved session from localStorage
+        try {
+          const state = await localforage.getItem('dps-calc-state');
+          store.updateImportedData(state as ImportableData);
+        } catch (e) {
+          // If state couldn't be loaded (or there wasn't any), then try to load the username and lookup stats, at least
+          try {
+            const username = await localforage.getItem('dps-calc-username');
+            store.updateUIState({ username: username as string });
+            if (username) {
+              store.fetchCurrentPlayerSkills();
+            }
+          } catch (e2) { /* do nothing */ }
+        }
+
+        store.startStorageUpdater();
+      }
+
+      const monster = searchParams.get('monster');
+      if (monster) {
+        const target = store.availableMonsters.find((m) => m.id === parseInt(monster));
+        if (target) {
+          // If a monster ID was provided, set the active monster to it.
+          store.updateMonster(target);
+        }
+      }
+
+      setLoaded(true);
+    };
+
+    if (loaded) return;
+    doFirstLoad();
+
     // This code is necessary because searchParams may change later, when we strip the query params from the URL
     if (loaded) return;
     setLoaded(true);
 
-    const id = searchParams.get('id');
-    if (id) {
-      // If there was a share ID provided, load the data for it into the calculator
-      store.loadShortlink(id).then(() => {
-        window.history.replaceState({}, '', process.env.NEXT_PUBLIC_BASE_PATH);
-      });
-    } else {
-      // Else...
-      // Load any previously saved session from localStorage
-      localforage.getItem('dps-calc-state')
-        .then((s) => store.updateImportedData(s as ImportableData))
-        .catch(() => {})
-        // Also load username from browser storage if there is one and lookup stats
-        .finally(() => localforage.getItem('dps-calc-username')
-          .then((u) => {
-            store.updateUIState({ username: u as string });
-            if (u) store.fetchCurrentPlayerSkills();
-          })
-          .catch(() => {})
-          .finally(() => store.startStorageUpdater()));
-    }
-
-    const monster = searchParams.get('monster');
-    if (monster) {
-      const target = store.availableMonsters.find((m) => m.id === parseInt(monster));
-      if (target) {
-        // If a monster ID was provided, set the active monster to it.
-        store.updateMonster(target);
-      }
-    }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [searchParams]);
 

--- a/src/app/components/ShareModal.tsx
+++ b/src/app/components/ShareModal.tsx
@@ -2,8 +2,6 @@ import React, { createRef, useEffect, useState } from 'react';
 import { observer } from 'mobx-react-lite';
 import { useStore } from '@/state';
 import Modal from '@/app/components/generic/Modal';
-import { ImportableData } from '@/types/State';
-import { toJS } from 'mobx';
 import { generateShortlink, isDevServer } from '@/utils';
 import { toast } from 'react-toastify';
 import { IconClipboardCopy } from '@tabler/icons-react';
@@ -17,28 +15,19 @@ const ShareModal: React.FC = observer(() => {
   const [shareId, setShareId] = useState('');
   const [error, setError] = useState(false);
 
-  const generateShareLink = async () => {
-    setShareId('');
-    setError(false);
-
-    // Get the data we need from the internal store
-    const data: ImportableData = {
-      loadouts: toJS(store.loadouts),
-      monster: toJS(store.monster),
-      selectedLoadout: store.selectedLoadout,
-    };
-
-    // Make an API call to generate a share link
-    try {
-      setShareId(await generateShortlink(data));
-    } catch (e) {
-      setError(true);
-    }
-  };
-
   useEffect(() => {
+    async function generate() {
+      setShareId('');
+      setError(false);
+      try {
+        setShareId(await generateShortlink(store.asImportableData));
+      } catch (e) {
+        setError(true);
+      }
+    }
+
     if (ui.showShareModal) {
-      generateShareLink();
+      generate();
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, [ui.showShareModal]);

--- a/src/app/components/results/HitDistribution.tsx
+++ b/src/app/components/results/HitDistribution.tsx
@@ -5,7 +5,6 @@ import {
 import { NameType, ValueType } from 'recharts/types/component/DefaultTooltipContent';
 import hitsplat from '@/public/img/hitsplat.webp';
 import zero_hitsplat from '@/public/img/zero_hitsplat.png';
-import { ChartEntry } from '@/types/State';
 import { useTheme } from 'next-themes';
 import { useStore } from '@/state';
 import LazyImage from '@/app/components/generic/LazyImage';
@@ -40,9 +39,10 @@ const CustomTooltip: React.FC<TooltipProps<ValueType, NameType>> = ({ active, pa
   return null;
 };
 
-const HitDistribution: React.FC<{ dist: ChartEntry[] }> = observer(({ dist }) => {
+const HitDistribution: React.FC = observer(() => {
   const store = useStore();
-  const { prefs } = store;
+  const { prefs, calc, selectedLoadout } = store;
+  const dist = calc.loadouts[selectedLoadout]?.hitDist || [];
   const data = prefs.hitDistsHideZeros ? dist.slice(1) : dist;
 
   const { resolvedTheme } = useTheme();

--- a/src/app/components/results/PlayerVsNPCResultsContainer.tsx
+++ b/src/app/components/results/PlayerVsNPCResultsContainer.tsx
@@ -1,31 +1,25 @@
 import React from 'react';
-import { observer } from 'mobx-react-lite';
-import { useStore } from '@/state';
 import HitDistribution from '@/app/components/results/HitDistribution';
 import PlayerVsNPCResultsTable from '@/app/components/results/PlayerVsNPCResultsTable';
 
-const ResultsContainer = observer(() => {
-  const store = useStore();
-
-  return (
-    <div className="grow basis-1/4 md:mt-9 flex flex-col">
+const ResultsContainer = () => (
+  <div className="grow basis-1/4 md:mt-9 flex flex-col">
+    <div
+      className="sm:rounded shadow-lg bg-tile dark:bg-dark-300"
+    >
       <div
-        className="sm:rounded shadow-lg bg-tile dark:bg-dark-300"
+        className="px-4 py-3.5 border-b-body-400 bg-body-100 dark:bg-dark-400 dark:border-b-dark-200 border-b md:rounded md:rounded-bl-none md:rounded-br-none flex justify-between items-center"
       >
-        <div
-          className="px-4 py-3.5 border-b-body-400 bg-body-100 dark:bg-dark-400 dark:border-b-dark-200 border-b md:rounded md:rounded-bl-none md:rounded-br-none flex justify-between items-center"
-        >
-          <h2 className="font-serif text-lg tracking-tight font-bold dark:text-white">
-            Results
-          </h2>
-        </div>
-        <div className="overflow-x-auto max-w-[100vw]">
-          <PlayerVsNPCResultsTable />
-        </div>
+        <h2 className="font-serif text-lg tracking-tight font-bold dark:text-white">
+          Results
+        </h2>
       </div>
-      <HitDistribution dist={store.calc.loadouts[store.selectedLoadout]?.hitDist || []} />
+      <div className="overflow-x-auto max-w-[100vw]">
+        <PlayerVsNPCResultsTable />
+      </div>
     </div>
-  );
-});
+    <HitDistribution />
+  </div>
+);
 
 export default ResultsContainer;

--- a/src/state.tsx
+++ b/src/state.tsx
@@ -14,7 +14,7 @@ import { Monster } from '@/types/Monster';
 import { MonsterAttribute } from '@/enums/MonsterAttribute';
 import { toast } from 'react-toastify';
 import {
-  Debouncer, fetchPlayerSkills, fetchShortlinkData, getCombatStylesForCategory, PotionMap,
+  fetchPlayerSkills, fetchShortlinkData, getCombatStylesForCategory, PotionMap,
 } from '@/utils';
 import { ComputeBasicRequest, ComputeReverseRequest, WorkerRequestType } from '@/worker/CalcWorkerTypes';
 import getMonsters from '@/lib/Monsters';
@@ -33,8 +33,6 @@ import {
 } from './enums/Prayer';
 import Potion from './enums/Potion';
 import { WikiSyncer } from './wikisync/WikiSyncer';
-
-const CALC_DEBOUNCE_MS: number = 250;
 
 const EMPTY_CALC_LOADOUT = {} as CalculatedLoadout;
 
@@ -390,7 +388,6 @@ class GlobalState implements State {
       console.warn('[GlobalState] CalcWorker is already set!');
     }
     worker.initWorker();
-    worker.setDebouncer(new Debouncer(CALC_DEBOUNCE_MS));
     this.calcWorker = worker;
   }
 
@@ -716,8 +713,8 @@ class GlobalState implements State {
     this.calc.loadouts = calculatedLoadouts;
 
     const data: Extract<ComputeBasicRequest['data'], ComputeReverseRequest['data']> = {
-      loadouts: this.loadouts,
-      monster: this.monster,
+      loadouts: toJS(this.loadouts),
+      monster: toJS(this.monster),
       calcOpts: {
         includeTtkDist: this.prefs.showTtkComparison,
         detailedOutput: this.debug,

--- a/src/state.tsx
+++ b/src/state.tsx
@@ -301,6 +301,17 @@ class GlobalState implements State {
   }
 
   /**
+   * Get the importable version of the current UI state
+   */
+  get asImportableData(): ImportableData {
+    return {
+      loadouts: toJS(this.loadouts),
+      monster: toJS(this.monster),
+      selectedLoadout: this.selectedLoadout,
+    };
+  }
+
+  /**
    * Get the currently selected player (loadout)
    */
   get player() {
@@ -435,7 +446,7 @@ class GlobalState implements State {
       });
     }
 
-    // Expand some minified fields with thier full metadata
+    // Expand some minified fields with their full metadata
     const loadouts = parseLoadoutsFromImportedData(data);
 
     // manually recompute equipment in case their metadata has changed since the shortlink was created

--- a/src/state.tsx
+++ b/src/state.tsx
@@ -376,6 +376,7 @@ class GlobalState implements State {
   startStorageUpdater() {
     if (this.storageUpdater) {
       console.warn('[GlobalState] StorageUpdater is already set!');
+      return;
     }
     this.storageUpdater = autorun(() => {
       // Save their application state to browser storage

--- a/src/worker/CalcWorker.tsx
+++ b/src/worker/CalcWorker.tsx
@@ -66,9 +66,7 @@ export class CalcWorker {
       return Promise.reject(new Error('worker is not initialized and cannot handle requests'));
     }
 
-    if (Object.prototype.hasOwnProperty.call(this.debouncers, req.type)) {
-      await this.debouncers[req.type]?.debounce();
-    }
+    await this.debouncers[req.type]?.debounce();
 
     // we use these ids to map the response back to the promise
     this.sequenceId += 1;


### PR DESCRIPTION
Persists the current browser session's `ImportableData`, the same data that would be loaded from a shortlink. Also includes a bug fix for worker debouncing that was noticed while testing this implementation.

Closes #214, #185