### PR TITLE
Reverse calc details to their own panel

### DIFF
--- a/src/app/components/results/DebugPanels.tsx
+++ b/src/app/components/results/DebugPanels.tsx
@@ -13,6 +13,7 @@ const DebugPanels: React.FC = observer(() => {
 
   const { calc, player, selectedLoadout } = store;
   const details: DetailEntry[] = calc.loadouts[selectedLoadout]?.details || [];
+  const npcDetails: DetailEntry[] = calc.loadouts[selectedLoadout]?.npcDetails || [];
 
   return (
     <>
@@ -67,6 +68,34 @@ const DebugPanels: React.FC = observer(() => {
           </thead>
           <tbody>
             {details.map((d) => (
+              <tr key={d.label} className="hover:bg-btns-100 hover:dark:bg-btns-100">
+                <td className={`border text-center w-1/2 border-l ${d.highlight ? 'dark:text-white text-black font-bold' : 'dark:text-body-400 text-gray-400'}`}>{d.label}</td>
+                <td className={`border text-center w-1/2 border-l ${d.highlight ? 'dark:text-white text-black font-bold' : 'dark:text-body-400 text-gray-400'}`}>{d.displayValue}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      </SectionAccordion>
+      <SectionAccordion
+        title={(
+          <div className="flex items-center gap-2">
+            <div className="w-6 flex justify-center"><LazyImage src={debug.src} /></div>
+            <h3 className="font-serif font-bold">
+              [Debug] Reverse Details
+            </h3>
+          </div>
+        )}
+        defaultIsOpen
+      >
+        <table className="w-full">
+          <thead>
+            <tr>
+              <th className="text-center w-1/2 border-x border-y font-bold font-serif bg-btns-400 dark:bg-dark-500 text-white">Label</th>
+              <th className="text-center w-1/2 border-r border-y font-bold font-serif bg-btns-400 dark:bg-dark-500 text-white">Value</th>
+            </tr>
+          </thead>
+          <tbody>
+            {npcDetails.map((d) => (
               <tr key={d.label} className="hover:bg-btns-100 hover:dark:bg-btns-100">
                 <td className={`border text-center w-1/2 border-l ${d.highlight ? 'dark:text-white text-black font-bold' : 'dark:text-body-400 text-gray-400'}`}>{d.label}</td>
                 <td className={`border text-center w-1/2 border-l ${d.highlight ? 'dark:text-white text-black font-bold' : 'dark:text-body-400 text-gray-400'}`}>{d.displayValue}</td>

--- a/src/state.tsx
+++ b/src/state.tsx
@@ -412,13 +412,7 @@ class GlobalState implements State {
   }
 
   updateCalcResults(calc: PartialDeep<Calculator>) {
-    this.calc = merge(this.calc, calc, (obj, src, key) => {
-      // When we're handling the details array, merge the obj + src together instead of replacing
-      if (key === 'details' && Array.isArray(src) && Array.isArray(obj)) {
-        return [...obj, ...src];
-      }
-      return undefined;
-    });
+    this.calc = merge(this.calc, calc);
   }
 
   async loadShortlink(linkId: string) {

--- a/src/types/State.ts
+++ b/src/types/State.ts
@@ -67,11 +67,12 @@ export interface CalculatedLoadout {
 
   // Misc
   details?: DetailEntry[],
+  npcDetails?: DetailEntry[],
   userIssues?: UserIssue[],
 }
 
 export type PlayerVsNPCCalculatedLoadout = Pick<CalculatedLoadout, 'npcDefRoll' | 'maxHit' | 'maxAttackRoll' | 'accuracy' | 'dps' | 'ttk' | 'hitDist' | 'ttkDist' | 'details' | 'userIssues'>;
-export type NPCVsPlayerCalculatedLoadout = Pick<CalculatedLoadout, 'playerDefRoll' | 'npcMaxAttackRoll' | 'npcMaxHit' | 'npcDps' | 'npcAccuracy' | 'avgDmgTaken' | 'details' | 'userIssues'>;
+export type NPCVsPlayerCalculatedLoadout = Pick<CalculatedLoadout, 'playerDefRoll' | 'npcMaxAttackRoll' | 'npcMaxHit' | 'npcDps' | 'npcAccuracy' | 'avgDmgTaken' | 'npcDetails' | 'userIssues'>;
 
 export interface Calculator {
   loadouts: CalculatedLoadout[]

--- a/src/worker/worker.ts
+++ b/src/worker/worker.ts
@@ -67,7 +67,7 @@ const computeMvPValues: Handler<WorkerRequestType.COMPUTE_REVERSE> = async (data
       npcAccuracy: calc.getHitChance(),
       playerDefRoll: calc.getPlayerDefenceRoll(),
       avgDmgTaken: calc.getAverageDamageTaken(),
-      details: calc.details,
+      npcDetails: calc.details,
     });
     const end = new Date().getTime();
 


### PR DESCRIPTION
We were still causing duplicate react key issues since some some of the player details and npc details have the same name. There's already some dedupe protection in CalcDetails.ts, so we just need to not combine the arrays.

Also just more useful to have them separated visually anyway.