### PR TITLE
state: recalculate on stance change

### DIFF
--- a/src/lib/Equipment.ts
+++ b/src/lib/Equipment.ts
@@ -1,7 +1,7 @@
 import { EquipmentPiece, Player, PlayerEquipment } from '@/types/Player';
 import { Monster } from '@/types/Monster';
 import { keys } from '@/utils';
-import { TOMBS_OF_AMASCUT_MONSTER_IDS } from '@/lib/constants';
+import { CAST_STANCES, TOMBS_OF_AMASCUT_MONSTER_IDS } from '@/lib/constants';
 import { sum } from 'd3-array';
 import equipment from '../../cdn/json/equipment.json';
 import generatedEquipmentAliases from './EquipmentAliases';
@@ -289,7 +289,7 @@ export const calculateEquipmentBonusesFromGear = (player: Player, monster: Monst
     totals.bonuses.str += Math.max(0, Math.trunc((defenceSum - 800) / 12) - 38);
   }
 
-  if (player.spell?.spellbook === 'ancient') {
+  if (player.spell?.spellbook === 'ancient' && CAST_STANCES.includes(player.style.stance)) {
     const virtusPieces = sum([playerEquipment.head?.name, playerEquipment.body?.name, playerEquipment.legs?.name], (i) => (i?.includes('Virtus') ? 1 : 0));
     totals.bonuses.magic_str += 30 * virtusPieces;
   }

--- a/src/state.tsx
+++ b/src/state.tsx
@@ -622,7 +622,7 @@ class GlobalState implements State {
 
     this.loadouts[loadoutIx] = merge(this.loadouts[loadoutIx], player);
     if (!this.prefs.manualMode) {
-      if (eq || Object.hasOwn(player, 'spell')) {
+      if (eq || Object.hasOwn(player, 'spell') || Object.hasOwn(player, 'style')) {
         this.recalculateEquipmentBonusesFromGear(loadoutIx);
       }
     }


### PR DESCRIPTION
Fixes a few issues with magic damage bonus in particular not being recalculated based on whether the bonus applies to manual cast. Virtus and Tumeken's shadow need to recalculate, since they only/only not apply to spell casts, respectively.

Closes #315
Closes #316