### PR TITLE
Fix comment for Harralander tar.

### DIFF
--- a/src/lib/Equipment.ts
+++ b/src/lib/Equipment.ts
@@ -145,7 +145,7 @@ const ammoForRangedWeapons: { [weapon: number]: number[] } = {
   10149: [10142], // Swamp lizard, Guam tar
   10146: [10143], // Orange salamander, Marrentill tar
   10147: [10144], // Red salamander, Tarromin tar
-  10148: [10145], // Black salamander, Guam tar
+  10148: [10145], // Black salamander, Harralander tar
   28834: [28837], // Tecu salamander, Irit tar
   28869: [28872, 28878], // Hunters' sunlight crossbow
   29000: [28991], // Eclipse atlatl


### PR DESCRIPTION
The id is right, but the comment said "Guam tar" when it's supposed to be "Harralander tar". Probably a copy and paste error.