### PR TITLE
Add Dizana's max cape to dizanasQuiverCharged bonus.

### DIFF
--- a/src/lib/Equipment.ts
+++ b/src/lib/Equipment.ts
@@ -303,7 +303,8 @@ export const calculateEquipmentBonusesFromGear = (player: Player, monster: Monst
   }
 
   const cape = playerEquipment.cape;
-  const dizanasQuiverCharged = cape?.name === "Blessed dizana's quiver"
+  const dizanasQuiverCharged = cape?.name === "Dizana's max cape"
+    || cape?.name === "Blessed dizana's quiver"
     || (cape?.name === "Dizana's quiver" && cape?.version === 'Charged');
   if (dizanasQuiverCharged && ammoApplicability(player.equipment.weapon?.id, player.equipment.ammo?.id) === AmmoApplicability.INCLUDED) {
     totals.offensive.ranged += 10;


### PR DESCRIPTION
When I use the DPS Wiki button on Runelite it loads up the calculator with the Dizana's max cape, but the calculator isn't giving the charged quiver bonus (which it should). I think it either needs to be added here or the Dizana's max cape needs to be made an EquipmentAlias of Blessed dizana's quiver.

https://dps.osrs.wiki?id=PhalanxCoveredBehind
https://oldschool.runescape.wiki/w/Dizana%27s_max_cape