### PR TITLE
Feat: Added additional functionality to loadout tabs

### DIFF
--- a/src/app/components/player/LoadoutTabs.tsx
+++ b/src/app/components/player/LoadoutTabs.tsx
@@ -73,6 +73,7 @@ const DraggableTabsProvider: React.FC<{ children: React.ReactNode }> = ({
 
   const handleMouseDown = useCallback((e: React.MouseEvent, index: number) => {
     if (e.button === 1) {
+      e.preventDefault();
       deleteLoadout(index);
       return;
     }

--- a/src/app/components/player/LoadoutTabs.tsx
+++ b/src/app/components/player/LoadoutTabs.tsx
@@ -1,0 +1,189 @@
+import { useStore } from "@/state";
+import { createContext, useContext, useState } from "react";
+
+const LoadoutTabs: React.FC = () => {
+  const store = useStore();
+  const { loadouts } = store;
+
+  return (
+    <DraggableTabsProvider>
+      {loadouts.map((_, ix) => (
+        <LoadoutTabButton index={ix} />
+      ))}
+    </DraggableTabsProvider>
+  );
+};
+
+const LoadoutTabButton: React.FC<{ index: number }> = ({ index }) => {
+  const {
+    calculateButtonClasses,
+    calculateButtonTransform,
+    handleMouseDown,
+    handleMouseOver,
+    handleMouseUp,
+  } = useDraggableTabs(index);
+  return (
+    <div>
+      <button
+        type="button"
+        key={index}
+        className={calculateButtonClasses()}
+        style={{
+          transform: `translate(${calculateButtonTransform()}px)`,
+        }}
+        onMouseDown={handleMouseDown}
+        onMouseUp={handleMouseUp}
+        onMouseOver={handleMouseOver}
+      >
+        <span className="select-none pointer-events-none">{index + 1}</span>
+      </button>
+    </div>
+  );
+};
+
+interface DraggableTabs {
+  calculateButtonClasses(index: number): string;
+  calculateButtonTransform(index: number): number;
+  handleMouseDown(e: React.MouseEvent, index: number): void;
+  handleMouseOver(e: React.MouseEvent, index: number): void;
+  handleMouseUp(e: React.MouseEvent, index: number): void;
+}
+
+const DraggableTabsContext = createContext<DraggableTabs>({
+  calculateButtonClasses: () => "",
+  calculateButtonTransform: () => 0,
+  handleMouseDown: () => {},
+  handleMouseOver: () => {},
+  handleMouseUp: () => {},
+});
+
+const DraggableTabsProvider: React.FC<{ children: React.ReactNode }> = ({
+  children,
+}) => {
+  const store = useStore();
+  const { loadouts, selectedLoadout } = store;
+
+  const [draggedTab, setDraggedTab] = useState(-1);
+  const [dragStartCoords, setDragStartCoords] = useState({ x: 0, y: 0 });
+  const [draggedOverTab, setDraggedOverTab] = useState(-1);
+  const [dragTimeout, setDragTimeout] = useState<NodeJS.Timeout | null>(null);
+  const [transitionOn, setTransitionOn] = useState(true);
+
+  const calculateButtonClasses = (index: number) =>
+    [
+      "w-[40px] h-full text-left first:md:rounded-tl px-4 py-1 border-l-2 first:border-l-0",
+      "last:rounded-tr border-body-100 dark:border-dark-300",
+      selectedLoadout === index
+        ? "bg-orange-400 dark:bg-orange-700"
+        : "bg-btns-400 dark:bg-dark-400",
+      transitionOn ? "transition-transform  transition-colors" : "",
+      draggedTab > -1 ? "cursor-grabbing" : "cursor-pointer",
+    ].join(" ");
+
+  const calculateButtonTransform = (index: number) => {
+    const elementWidth = 40;
+
+    if (draggedTab === -1 || draggedOverTab === -1) return 0;
+    if (index === draggedTab && index === draggedOverTab) return 0;
+    if (index === draggedTab) {
+      return elementWidth * (draggedOverTab - draggedTab);
+    }
+    if (index < draggedTab && index >= draggedOverTab) return elementWidth;
+    if (index > draggedTab && index <= draggedOverTab) return -elementWidth;
+
+    return 0;
+  };
+
+  const handleMouseDown = (e: React.MouseEvent, index: number) => {
+    if (e.button === 1) {
+      store.deleteLoadout(index);
+      return;
+    }
+    store.setSelectedLoadout(index);
+    const rects = e.currentTarget.getBoundingClientRect();
+    setDragTimeout(
+      setTimeout(() => {
+        setDraggedTab(index);
+        setDraggedOverTab(index);
+        setDragStartCoords({ x: rects.x, y: rects.y });
+      }, 100)
+    );
+  };
+
+  const handleMouseUp = (e: React.MouseEvent, index: number) => {
+    if (dragTimeout) clearTimeout(dragTimeout);
+
+    if (draggedTab > -1 && draggedOverTab > -1) {
+      store.setSelectedLoadout(draggedOverTab);
+      setTransitionOn(false);
+      setTimeout(() => {
+        setTransitionOn(true);
+      }, 150);
+
+      const newLoadouts = [...loadouts];
+      newLoadouts.splice(draggedTab, 1);
+      newLoadouts.splice(draggedOverTab, 0, loadouts[draggedTab]);
+
+      store.setLoadouts([...newLoadouts]);
+
+      setDraggedTab(-1);
+      setDraggedOverTab(-1);
+    }
+  };
+
+  const handleMouseOver = (e: React.MouseEvent, index: number) => {
+    if (draggedTab !== index) {
+      const deltaX = e.clientX - dragStartCoords.x;
+      setDraggedOverTab(
+        Math.max(
+          0,
+          Math.min(
+            loadouts.length - 1,
+            draggedTab + Math.round((deltaX - 20) / 40)
+          )
+        )
+      );
+      return;
+    }
+  };
+
+  const handleContainerMouseLeave = () => {
+    setDraggedTab(-1);
+    setDraggedOverTab(-1);
+  };
+
+  return (
+    <DraggableTabsContext.Provider
+      value={{
+        calculateButtonClasses,
+        calculateButtonTransform,
+        handleMouseDown,
+        handleMouseOver,
+        handleMouseUp,
+      }}
+    >
+      <div
+        className="my-1 flex h-full relative"
+        onMouseLeave={handleContainerMouseLeave}
+      >
+        {children}
+      </div>
+    </DraggableTabsContext.Provider>
+  );
+};
+
+const useDraggableTabs = (index: number) => {
+  const handlers = useContext(DraggableTabsContext);
+
+  return {
+    calculateButtonClasses: () => handlers.calculateButtonClasses(index),
+    calculateButtonTransform: () => handlers.calculateButtonTransform(index),
+    handleMouseDown: (e: React.MouseEvent) =>
+      handlers.handleMouseDown(e, index),
+    handleMouseOver: (e: React.MouseEvent) =>
+      handlers.handleMouseOver(e, index),
+    handleMouseUp: (e: React.MouseEvent) => handlers.handleMouseUp(e, index),
+  };
+};
+
+export default LoadoutTabs;

--- a/src/app/components/player/LoadoutTabs.tsx
+++ b/src/app/components/player/LoadoutTabs.tsx
@@ -199,22 +199,20 @@ const LoadoutTabButton: React.FC<{ index: number }> = ({ index }) => {
     handleMouseUp,
   } = useDraggableTabs(index);
   return (
-    <div>
-      <button
-        type="button"
-        className={calculateButtonClasses()}
-        style={{
-          transform: `translate(${calculateButtonTransform()}px)`,
-        }}
-        onKeyDown={handleKeyDown}
-        onMouseDown={handleMouseDown}
-        onMouseUp={handleMouseUp}
-        // eslint-disable-next-line jsx-a11y/mouse-events-have-key-events
-        onMouseOver={handleMouseOver}
-      >
-        <span className="select-none pointer-events-none">{index + 1}</span>
-      </button>
-    </div>
+    <button
+      type="button"
+      className={calculateButtonClasses()}
+      style={{
+        transform: `translate(${calculateButtonTransform()}px)`,
+      }}
+      onKeyDown={handleKeyDown}
+      onMouseDown={handleMouseDown}
+      onMouseUp={handleMouseUp}
+      // eslint-disable-next-line jsx-a11y/mouse-events-have-key-events
+      onMouseOver={handleMouseOver}
+    >
+      <span className="select-none pointer-events-none">{index + 1}</span>
+    </button>
   );
 };
 

--- a/src/app/components/player/LoadoutTabs.tsx
+++ b/src/app/components/player/LoadoutTabs.tsx
@@ -1,56 +1,22 @@
-import { useStore } from "@/state";
-import { createContext, useContext, useState } from "react";
-
-const LoadoutTabs: React.FC = () => {
-  const store = useStore();
-  const { loadouts } = store;
-
-  return (
-    <DraggableTabsProvider>
-      {loadouts.map((_, ix) => (
-        <LoadoutTabButton index={ix} />
-      ))}
-    </DraggableTabsProvider>
-  );
-};
-
-const LoadoutTabButton: React.FC<{ index: number }> = ({ index }) => {
-  const {
-    calculateButtonClasses,
-    calculateButtonTransform,
-    handleMouseDown,
-    handleMouseOver,
-    handleMouseUp,
-  } = useDraggableTabs(index);
-  return (
-    <div>
-      <button
-        type="button"
-        key={index}
-        className={calculateButtonClasses()}
-        style={{
-          transform: `translate(${calculateButtonTransform()}px)`,
-        }}
-        onMouseDown={handleMouseDown}
-        onMouseUp={handleMouseUp}
-        onMouseOver={handleMouseOver}
-      >
-        <span className="select-none pointer-events-none">{index + 1}</span>
-      </button>
-    </div>
-  );
-};
+import { useStore } from '@/state';
+import {
+  createContext,
+  useCallback,
+  useContext,
+  useMemo,
+  useState,
+} from 'react';
 
 interface DraggableTabs {
   calculateButtonClasses(index: number): string;
   calculateButtonTransform(index: number): number;
   handleMouseDown(e: React.MouseEvent, index: number): void;
   handleMouseOver(e: React.MouseEvent, index: number): void;
-  handleMouseUp(e: React.MouseEvent, index: number): void;
+  handleMouseUp(): void;
 }
 
 const DraggableTabsContext = createContext<DraggableTabs>({
-  calculateButtonClasses: () => "",
+  calculateButtonClasses: () => '',
   calculateButtonTransform: () => 0,
   handleMouseDown: () => {},
   handleMouseOver: () => {},
@@ -61,7 +27,13 @@ const DraggableTabsProvider: React.FC<{ children: React.ReactNode }> = ({
   children,
 }) => {
   const store = useStore();
-  const { loadouts, selectedLoadout } = store;
+  const {
+    loadouts,
+    selectedLoadout,
+    deleteLoadout,
+    setLoadouts,
+    setSelectedLoadout,
+  } = store;
 
   const [draggedTab, setDraggedTab] = useState(-1);
   const [dragStartCoords, setDragStartCoords] = useState({ x: 0, y: 0 });
@@ -69,52 +41,57 @@ const DraggableTabsProvider: React.FC<{ children: React.ReactNode }> = ({
   const [dragTimeout, setDragTimeout] = useState<NodeJS.Timeout | null>(null);
   const [transitionOn, setTransitionOn] = useState(true);
 
-  const calculateButtonClasses = (index: number) =>
-    [
-      "w-[40px] h-full text-left first:md:rounded-tl px-4 py-1 border-l-2 first:border-l-0",
-      "last:rounded-tr border-body-100 dark:border-dark-300",
+  const calculateButtonClasses = useCallback(
+    (index: number) => [
+      'w-[40px] h-full text-left first:md:rounded-tl px-4 py-1 border-l-2 first:border-l-0',
+      'last:rounded-tr border-body-100 dark:border-dark-300',
       selectedLoadout === index
-        ? "bg-orange-400 dark:bg-orange-700"
-        : "bg-btns-400 dark:bg-dark-400",
-      transitionOn ? "transition-transform  transition-colors" : "",
-      draggedTab > -1 ? "cursor-grabbing" : "cursor-pointer",
-    ].join(" ");
+        ? 'bg-orange-400 dark:bg-orange-700'
+        : 'bg-btns-400 dark:bg-dark-400',
+      transitionOn ? 'transition-transform  transition-colors' : '',
+      draggedTab > -1 ? 'cursor-grabbing' : 'cursor-pointer',
+    ].join(' '),
+    [selectedLoadout, transitionOn, draggedTab],
+  );
 
-  const calculateButtonTransform = (index: number) => {
-    const elementWidth = 40;
+  const calculateButtonTransform = useCallback(
+    (index: number) => {
+      const elementWidth = 40;
 
-    if (draggedTab === -1 || draggedOverTab === -1) return 0;
-    if (index === draggedTab && index === draggedOverTab) return 0;
-    if (index === draggedTab) {
-      return elementWidth * (draggedOverTab - draggedTab);
-    }
-    if (index < draggedTab && index >= draggedOverTab) return elementWidth;
-    if (index > draggedTab && index <= draggedOverTab) return -elementWidth;
+      if (draggedTab === -1 || draggedOverTab === -1) return 0;
+      if (index === draggedTab && index === draggedOverTab) return 0;
+      if (index === draggedTab) {
+        return elementWidth * (draggedOverTab - draggedTab);
+      }
+      if (index < draggedTab && index >= draggedOverTab) return elementWidth;
+      if (index > draggedTab && index <= draggedOverTab) return -elementWidth;
 
-    return 0;
-  };
+      return 0;
+    },
+    [draggedTab, draggedOverTab],
+  );
 
-  const handleMouseDown = (e: React.MouseEvent, index: number) => {
+  const handleMouseDown = useCallback((e: React.MouseEvent, index: number) => {
     if (e.button === 1) {
-      store.deleteLoadout(index);
+      deleteLoadout(index);
       return;
     }
-    store.setSelectedLoadout(index);
+    setSelectedLoadout(index);
     const rects = e.currentTarget.getBoundingClientRect();
     setDragTimeout(
       setTimeout(() => {
         setDraggedTab(index);
         setDraggedOverTab(index);
         setDragStartCoords({ x: rects.x, y: rects.y });
-      }, 100)
+      }, 100),
     );
-  };
+  }, [setSelectedLoadout, deleteLoadout]);
 
-  const handleMouseUp = (e: React.MouseEvent, index: number) => {
+  const handleMouseUp = useCallback(() => {
     if (dragTimeout) clearTimeout(dragTimeout);
 
     if (draggedTab > -1 && draggedOverTab > -1) {
-      store.setSelectedLoadout(draggedOverTab);
+      setSelectedLoadout(draggedOverTab);
       setTransitionOn(false);
       setTimeout(() => {
         setTransitionOn(true);
@@ -124,44 +101,55 @@ const DraggableTabsProvider: React.FC<{ children: React.ReactNode }> = ({
       newLoadouts.splice(draggedTab, 1);
       newLoadouts.splice(draggedOverTab, 0, loadouts[draggedTab]);
 
-      store.setLoadouts([...newLoadouts]);
+      setLoadouts([...newLoadouts]);
 
       setDraggedTab(-1);
       setDraggedOverTab(-1);
     }
-  };
+  }, [dragTimeout, draggedTab, draggedOverTab, loadouts, setSelectedLoadout, setLoadouts]);
 
-  const handleMouseOver = (e: React.MouseEvent, index: number) => {
-    if (draggedTab !== index) {
-      const deltaX = e.clientX - dragStartCoords.x;
-      setDraggedOverTab(
-        Math.max(
-          0,
-          Math.min(
-            loadouts.length - 1,
-            draggedTab + Math.round((deltaX - 20) / 40)
-          )
-        )
-      );
-      return;
-    }
-  };
+  const handleMouseOver = useCallback(
+    (e: React.MouseEvent, index: number) => {
+      if (draggedTab !== index) {
+        const deltaX = e.clientX - dragStartCoords.x;
+        setDraggedOverTab(
+          Math.max(
+            0,
+            Math.min(
+              loadouts.length - 1,
+              draggedTab + Math.round((deltaX - 20) / 40),
+            ),
+          ),
+        );
+      }
+    },
+    [draggedTab, loadouts, dragStartCoords],
+  );
 
   const handleContainerMouseLeave = () => {
     setDraggedTab(-1);
     setDraggedOverTab(-1);
   };
 
+  const contextValue = useMemo(
+    () => ({
+      calculateButtonClasses,
+      calculateButtonTransform,
+      handleMouseDown,
+      handleMouseOver,
+      handleMouseUp,
+    }),
+    [
+      calculateButtonClasses,
+      calculateButtonTransform,
+      handleMouseDown,
+      handleMouseOver,
+      handleMouseUp,
+    ],
+  );
+
   return (
-    <DraggableTabsContext.Provider
-      value={{
-        calculateButtonClasses,
-        calculateButtonTransform,
-        handleMouseDown,
-        handleMouseOver,
-        handleMouseUp,
-      }}
-    >
+    <DraggableTabsContext.Provider value={contextValue}>
       <div
         className="my-1 flex h-full relative"
         onMouseLeave={handleContainerMouseLeave}
@@ -178,12 +166,51 @@ const useDraggableTabs = (index: number) => {
   return {
     calculateButtonClasses: () => handlers.calculateButtonClasses(index),
     calculateButtonTransform: () => handlers.calculateButtonTransform(index),
-    handleMouseDown: (e: React.MouseEvent) =>
-      handlers.handleMouseDown(e, index),
-    handleMouseOver: (e: React.MouseEvent) =>
-      handlers.handleMouseOver(e, index),
-    handleMouseUp: (e: React.MouseEvent) => handlers.handleMouseUp(e, index),
+    handleMouseDown: (e: React.MouseEvent) => handlers.handleMouseDown(e, index),
+    handleMouseOver: (e: React.MouseEvent) => handlers.handleMouseOver(e, index),
+    handleMouseUp: handlers.handleMouseUp,
   };
+};
+
+const LoadoutTabButton: React.FC<{ index: number }> = ({ index }) => {
+  const {
+    calculateButtonClasses,
+    calculateButtonTransform,
+    handleMouseDown,
+    handleMouseOver,
+    handleMouseUp,
+  } = useDraggableTabs(index);
+  return (
+    <div>
+      <button
+        type="button"
+        className={calculateButtonClasses()}
+        style={{
+          transform: `translate(${calculateButtonTransform()}px)`,
+        }}
+        onMouseDown={handleMouseDown}
+        onMouseUp={handleMouseUp}
+        // eslint-disable-next-line jsx-a11y/mouse-events-have-key-events
+        onMouseOver={handleMouseOver}
+      >
+        <span className="select-none pointer-events-none">{index + 1}</span>
+      </button>
+    </div>
+  );
+};
+
+const LoadoutTabs: React.FC = () => {
+  const store = useStore();
+  const { loadouts } = store;
+
+  return (
+    <DraggableTabsProvider>
+      {loadouts.map((_, ix) => (
+        // eslint-disable-next-line react/no-array-index-key
+        <LoadoutTabButton key={ix} index={ix} />
+      ))}
+    </DraggableTabsProvider>
+  );
 };
 
 export default LoadoutTabs;

--- a/src/app/components/player/PlayerContainer.tsx
+++ b/src/app/components/player/PlayerContainer.tsx
@@ -1,4 +1,4 @@
-import React, { useEffect } from 'react';
+import React from 'react';
 import { observer } from 'mobx-react-lite';
 import { useStore } from '@/state';
 import { calculateCombatLevel } from '@/utils';

--- a/src/app/components/player/PlayerContainer.tsx
+++ b/src/app/components/player/PlayerContainer.tsx
@@ -1,4 +1,4 @@
-import React from 'react';
+import React, { useEffect } from 'react';
 import { observer } from 'mobx-react-lite';
 import { useStore } from '@/state';
 import { calculateCombatLevel } from '@/utils';
@@ -6,6 +6,7 @@ import PlayerInnerContainer from '@/app/components/player/PlayerInnerContainer';
 import LoadoutName from '@/app/components/player/LoadoutName';
 import { IconPlus, IconTrash } from '@tabler/icons-react';
 import WikiSyncButton from 'src/app/components/player/WikiSyncButton';
+import LoadoutTabs from './LoadoutTabs';
 
 const PlayerContainer: React.FC = observer(() => {
   const store = useStore();
@@ -18,21 +19,7 @@ const PlayerContainer: React.FC = observer(() => {
       <div
         className="sm:rounded sm:rounded-b-none text-sm font-bold font-serif flex gap-2 items-center bg-transparent text-white border-b-4 border-orange-300 dark:border-orange-700"
       >
-        <div className="my-1 flex h-full">
-          {loadouts.map((l, ix) => (
-            <button
-              type="button"
-              // eslint-disable-next-line react/no-array-index-key
-              key={ix}
-              className={`min-w-[40px] text-left first:md:rounded-tl px-4 py-1 border-l-2 first:border-l-0 last:rounded-tr border-body-100 dark:border-dark-300 transition-colors ${selectedLoadout === ix ? 'bg-orange-400 dark:bg-orange-700' : 'bg-btns-400 dark:bg-dark-400'}`}
-              onClick={() => {
-                store.setSelectedLoadout(ix);
-              }}
-            >
-              {ix + 1}
-            </button>
-          ))}
-        </div>
+        <LoadoutTabs />
         <div>
           <button
             type="button"

--- a/src/state.tsx
+++ b/src/state.tsx
@@ -657,6 +657,10 @@ class GlobalState implements State {
     });
   }
 
+  setLoadouts(loadouts: Player[])  {
+    this.loadouts = loadouts;
+  }
+
   setSelectedLoadout(ix: number) {
     this.selectedLoadout = ix;
   }

--- a/src/state.tsx
+++ b/src/state.tsx
@@ -657,7 +657,7 @@ class GlobalState implements State {
     });
   }
 
-  setLoadouts(loadouts: Player[])  {
+  setLoadouts(loadouts: Player[]) {
     this.loadouts = loadouts;
   }
 


### PR DESCRIPTION
- Loadouts are now deleted when middle clicking the tab (similar to browser tab behaviour)
- Tabs can now be dragged over one another to rearrange the loadouts, to make comparison easier when screenshotting the output

Wasn't sure whether to split the components into separate files, or leave as a single module to avoid repo clutter. Let me know if it needs fixing.

https://github.com/weirdgloop/osrs-dps-calc/assets/34150671/0eddaa80-fc58-4081-b86a-bbec9168b5cf


