### PR TITLE
Correct Elemental damage with slayer helm

### DIFF
--- a/src/lib/PlayerVsNPCCalc.ts
+++ b/src/lib/PlayerVsNPCCalc.ts
@@ -593,7 +593,7 @@ export default class PlayerVsNPCCalc extends BaseCalc {
       maxHit += 10;
     }
 
-    //We need the basehit value for the elemental bonus later.
+    // We need the basehit value for the elemental bonus later.
     magicBaseHit = maxHit;
 
     let magicDmgBonus = this.player.bonuses.magic_str;

--- a/src/lib/PlayerVsNPCCalc.ts
+++ b/src/lib/PlayerVsNPCCalc.ts
@@ -592,7 +592,7 @@ export default class PlayerVsNPCCalc extends BaseCalc {
     if (this.isChargeSpellApplicable()) {
       maxHit += 10;
     }
-	
+
 	magicBaseHit = maxHit; //We need the basehit value for the elemental bonus later.
 
     let magicDmgBonus = this.player.bonuses.magic_str;
@@ -634,7 +634,7 @@ export default class PlayerVsNPCCalc extends BaseCalc {
     const spellement = this.player.spell?.element;
     if (this.monster.weakness && spellement) {
       if (spellement === this.monster.weakness.element) {
-        maxHit = maxHit + Math.trunc(magicBaseHit * (this.monster.weakness.severity/100))
+        maxHit += Math.trunc(magicBaseHit * (this.monster.weakness.severity / 100))
       }
     }
 

--- a/src/lib/PlayerVsNPCCalc.ts
+++ b/src/lib/PlayerVsNPCCalc.ts
@@ -523,6 +523,7 @@ export default class PlayerVsNPCCalc extends BaseCalc {
    */
   private getPlayerMaxMagicHit() {
     let maxHit: number = 0;
+    let magicBaseHit: number = 0;
     const magicLevel = this.player.skills.magic + this.player.boosts.magic;
     const { spell } = this.player;
 
@@ -591,6 +592,8 @@ export default class PlayerVsNPCCalc extends BaseCalc {
     if (this.isChargeSpellApplicable()) {
       maxHit += 10;
     }
+	
+	magicBaseHit = maxHit; //We need the basehit value for the elemental bonus later.
 
     let magicDmgBonus = this.player.bonuses.magic_str;
 
@@ -605,13 +608,6 @@ export default class PlayerVsNPCCalc extends BaseCalc {
       magicDmgBonus += 150;
     } else if (this.isWearingImbuedBlackMask() && buffs.onSlayerTask) {
       blackMaskBonus = true;
-    }
-
-    const spellement = this.player.spell?.element;
-    if (this.monster.weakness && spellement) {
-      if (spellement === this.monster.weakness.element) {
-        magicDmgBonus += this.monster.weakness.severity * 10;
-      }
     }
 
     for (const p of this.getCombatPrayers('magicDamageBonus')) {
@@ -633,6 +629,13 @@ export default class PlayerVsNPCCalc extends BaseCalc {
 
     if (this.isRevWeaponBuffApplicable()) {
       maxHit = Math.trunc(maxHit * 3 / 2);
+    }
+
+    const spellement = this.player.spell?.element;
+    if (this.monster.weakness && spellement) {
+      if (spellement === this.monster.weakness.element) {
+        maxHit = maxHit + Math.trunc(magicBaseHit * (this.monster.weakness.severity/100))
+      }
     }
 
     return maxHit;

--- a/src/lib/PlayerVsNPCCalc.ts
+++ b/src/lib/PlayerVsNPCCalc.ts
@@ -523,7 +523,6 @@ export default class PlayerVsNPCCalc extends BaseCalc {
    */
   private getPlayerMaxMagicHit() {
     let maxHit: number = 0;
-    let magicBaseHit: number = 0;
     const magicLevel = this.player.skills.magic + this.player.boosts.magic;
     const { spell } = this.player;
 
@@ -594,8 +593,7 @@ export default class PlayerVsNPCCalc extends BaseCalc {
     }
 
     // We need the basehit value for the elemental bonus later.
-    magicBaseHit = maxHit;
-
+    const baseMax = maxHit;
     let magicDmgBonus = this.player.bonuses.magic_str;
 
     if (this.isWearingSmokeStaff() && spell?.spellbook === 'standard') {
@@ -635,7 +633,7 @@ export default class PlayerVsNPCCalc extends BaseCalc {
     const spellement = this.player.spell?.element;
     if (this.monster.weakness && spellement) {
       if (spellement === this.monster.weakness.element) {
-        maxHit += Math.trunc(magicBaseHit * (this.monster.weakness.severity / 100));
+        maxHit += Math.trunc(baseMax * (this.monster.weakness.severity / 100));
       }
     }
 

--- a/src/lib/PlayerVsNPCCalc.ts
+++ b/src/lib/PlayerVsNPCCalc.ts
@@ -593,7 +593,8 @@ export default class PlayerVsNPCCalc extends BaseCalc {
       maxHit += 10;
     }
 
-	magicBaseHit = maxHit; //We need the basehit value for the elemental bonus later.
+    //We need the basehit value for the elemental bonus later.
+    magicBaseHit = maxHit;
 
     let magicDmgBonus = this.player.bonuses.magic_str;
 

--- a/src/lib/PlayerVsNPCCalc.ts
+++ b/src/lib/PlayerVsNPCCalc.ts
@@ -634,7 +634,7 @@ export default class PlayerVsNPCCalc extends BaseCalc {
     const spellement = this.player.spell?.element;
     if (this.monster.weakness && spellement) {
       if (spellement === this.monster.weakness.element) {
-        maxHit += Math.trunc(magicBaseHit * (this.monster.weakness.severity / 100))
+        maxHit += Math.trunc(magicBaseHit * (this.monster.weakness.severity / 100));
       }
     }
 


### PR DESCRIPTION
https://imgur.com/aUGOlsR shows max hit as 37, when its really 35

Correct order example:

Base max hit is 15 (including chaos gauntlet effect) 
Add in gear bonus: trunc(15 * 1.205) = 18
Add in slayer helm: trunc(18 * 1.15) = 20
Add in elemental bonus based on base max hit: 20 + trunc(15 * 1.0) = 35


