### PR TITLE
Move tome of fire and water scaling from post-roll to pre-roll

### DIFF
--- a/src/lib/PlayerVsNPCCalc.ts
+++ b/src/lib/PlayerVsNPCCalc.ts
@@ -637,6 +637,17 @@ export default class PlayerVsNPCCalc extends BaseCalc {
       }
     }
 
+    if (
+      this.wearing('Tome of fire')
+      && this.player.spell?.element === 'fire'
+      && this.player.spell?.name !== 'Flames of Zamorak'
+    ) {
+      maxHit = Math.trunc(maxHit * 11 / 10);
+    }
+    if (this.wearing('Tome of water') && this.player.spell?.element === 'water') {
+      maxHit = Math.trunc(maxHit * 11 / 10);
+    }
+
     return maxHit;
   }
 
@@ -892,17 +903,6 @@ export default class PlayerVsNPCCalc extends BaseCalc {
 
       this.track(DetailKey.GUARDIANS_DMG_BONUS, factor / divisor);
       dist = dist.transform(multiplyTransformer(factor, divisor));
-    }
-
-    if (
-      this.wearing('Tome of fire')
-      && this.player.spell?.element === 'fire'
-      && this.player.spell?.name !== 'Flames of Zamorak'
-    ) {
-      dist = dist.scaleDamage(11, 10);
-    }
-    if (this.wearing('Tome of water') && this.player.spell?.element === 'water') {
-      dist = dist.scaleDamage(11, 10);
     }
 
     if (this.player.style.type === 'magic' && this.isWearingAhrims()) {


### PR DESCRIPTION
The tome of fire and tome of water damage boosts are now applied as the last pre-roll step for calculating magic max hit, instead of being applied after the damage is rolled. This change was made silently by Jagex at some point prior to the Combat Rebalance changes (as evidenced by gathered hit data showing previously impossible hit values), and it has been confirmed via in-game testing to still be the case. It has also been confirmed to be applied last, after the elemental weakness boost is added.

Screenshot of hitting a 10 with a tome of fire equipped (impossible if it were post-roll due to rounding) - video also available in Discord
![image](https://github.com/weirdgloop/osrs-dps-calc/assets/87620453/29c4850d-c204-45ab-9bb8-28ef01ad1ca9)

Screenshot of hitting a 17 with water strike and tome of water (no other magic damage gear or prayers) against fire giants, proving that the 10% tome boost is applied after the elemental weakness is applied (since 8 * 1.1 rounds down to 8, so if it were applied first, the max hit would be 16)
![image](https://github.com/weirdgloop/osrs-dps-calc/assets/87620453/4f8aab96-6002-414f-861f-1e0b1a1c6392)