### PR TITLE
updateMonster: don't alter param monster inputs

### DIFF
--- a/src/state.tsx
+++ b/src/state.tsx
@@ -650,7 +650,10 @@ class GlobalState implements State {
       && monster.id !== this.monster.id
       && !Object.hasOwn(monster, 'inputs')
     ) {
-      monster.inputs = { ...INITIAL_MONSTER_INPUTS };
+      monster = {
+        ...monster,
+        inputs: INITIAL_MONSTER_INPUTS,
+      };
     }
 
     this.monster = merge(this.monster, monster, (obj, src) => {


### PR DESCRIPTION
Closes #338

Setting `monster.inputs = INITIAL_MONSTER_INPUTS` was including setting `monsterCurrentHp` to 150. We handle the reset of `monsterCurrentHp` elsewhere, but the real issue is that this was reassigning the inputs field on the source object, i.e. the one from JSON.

It was not actually the second+ click that was wrong. The first call to updateMonster would edit the inputs field, then trigger the monsterCurrentHp reset hiding the misbehaviour, then subsequent clicks would not trigger that reset due to the id changing, and the dirtied inputs field would be written.
