### PR TITLE
remove flames of zamorak special-casing

### DIFF
--- a/cdn/json/monsters.json
+++ b/cdn/json/monsters.json
@@ -27518,7 +27518,7 @@
     "skills": {
       "atk": 110,
       "def": 80,
-      "hp": 50,
+      "hp": 48,
       "magic": 110,
       "ranged": 110,
       "str": 110
@@ -38521,7 +38521,10 @@
       "stab": 60
     },
     "attributes": [],
-    "weakness": null
+    "weakness": {
+      "element": "fire",
+      "severity": 100
+    }
   },
   {
     "id": 11192,
@@ -63680,10 +63683,7 @@
       "spectral",
       "undead"
     ],
-    "weakness": {
-      "element": "water",
-      "severity": 100
-    }
+    "weakness": null
   },
   {
     "id": 6736,
@@ -67723,7 +67723,10 @@
     "attributes": [
       "dragon"
     ],
-    "weakness": null
+    "weakness": {
+      "element": "earth",
+      "severity": 50
+    }
   },
   {
     "id": 10398,
@@ -67766,7 +67769,10 @@
     "attributes": [
       "dragon"
     ],
-    "weakness": null
+    "weakness": {
+      "element": "earth",
+      "severity": 50
+    }
   },
   {
     "id": 3016,
@@ -90974,7 +90980,10 @@
     "attributes": [
       "dragon"
     ],
-    "weakness": null
+    "weakness": {
+      "element": "earth",
+      "severity": 50
+    }
   },
   {
     "id": 13031,
@@ -91016,7 +91025,10 @@
     "attributes": [
       "dragon"
     ],
-    "weakness": null
+    "weakness": {
+      "element": "earth",
+      "severity": 50
+    }
   },
   {
     "id": 10951,

--- a/cdn/json/spells.json
+++ b/cdn/json/spells.json
@@ -165,7 +165,7 @@
     "image": "Flames of Zamorak.png",
     "max_hit": 20,
     "spellbook": "standard",
-    "element": "fire"
+    "element": null
   },
   {
     "name": "Ghostly Grasp",

--- a/src/lib/PlayerVsNPCCalc.ts
+++ b/src/lib/PlayerVsNPCCalc.ts
@@ -652,7 +652,7 @@ export default class PlayerVsNPCCalc extends BaseCalc {
       minHit = this.trackFactor(DetailKey.MIN_HIT_SUNFIRE, maxHit, [1, 10]);
     }
 
-    if ((this.wearing('Tome of fire') && this.player.spell?.element === 'fire' && this.player.spell.name !== 'Flames of Zamorak')
+    if ((this.wearing('Tome of fire') && this.player.spell?.element === 'fire')
       || (this.wearing('Tome of water') && this.player.spell?.element === 'water')) {
       maxHit = this.trackFactor(DetailKey.MAX_HIT_TOME, maxHit, [11, 10]);
     }

--- a/src/types/Spell.ts
+++ b/src/types/Spell.ts
@@ -23,7 +23,7 @@ export function isBindSpell(spell: Spell | null): boolean {
 }
 
 export function getSpellMaxHit(spell: Spell, magicLevel: number): number {
-  if (!spell.element || spell.name === 'Flames of Zamorak') {
+  if (!spell.element) {
     return spell?.max_hit;
   }
 
@@ -66,14 +66,6 @@ export function getSpellMaxHit(spell: Spell, magicLevel: number): number {
 
 export function canUseSunfireRunes(spell: Spell | null): boolean {
   return spell?.element === 'fire';
-
-  // todo do we know for sure yet whether it's "fire spells" or "fire-rune spells"?
-  // return spell !== null && (
-  //   spell.name.includes('Fire')
-  //   || spell.name.includes('Smoke')
-  //   || spell.name.includes('Demonbane')
-  //   || ['Claws of Guthix', 'Flames of Zamorak', 'Saradomin Strike', 'Iban Blast', 'Undead Grasp'].includes(spell.name)
-  // );
 }
 
 // The available spellbooks


### PR DESCRIPTION
Flames of Zamorak is no longer considered a fire spell as of today's update

https://secure.runescape.com/m=news/a=13/pride-2024?oldschool=1