### PR TITLE
Enchanted bolt fixes

### DIFF
--- a/src/lib/PlayerVsNPCCalc.ts
+++ b/src/lib/PlayerVsNPCCalc.ts
@@ -964,7 +964,7 @@ export default class PlayerVsNPCCalc extends BaseCalc {
 
       if (this.wearing(['Onyx bolts (e)', 'Onyx dragon bolts (e)']) && !mattrs.includes(MonsterAttribute.UNDEAD)) {
         const chance = 0.11 * kandarinDiaryFactor;
-        const effectMax = max + Math.trunc(rangedLvl * (zaryte ? 32 : 20) / 100);
+        const effectMax = Math.trunc(max * (zaryte ? 132 : 120) / 100);
         dist = new AttackDistribution([
           new HitDistribution([
             ...standardHitDist.scaleProbability(1 - chance).hits,

--- a/src/lib/PlayerVsNPCCalc.ts
+++ b/src/lib/PlayerVsNPCCalc.ts
@@ -919,20 +919,24 @@ export default class PlayerVsNPCCalc extends BaseCalc {
       if (this.wearing(['Opal bolts (e)', 'Opal dragon bolts (e)'])) {
         const chance = 0.05 * kandarinDiaryFactor;
         const bonusDmg = Math.trunc(rangedLvl / (zaryte ? 9 : 10));
-        dist = dist.transform((h) => new HitDistribution([
-          new WeightedHit(chance, [new Hitsplat(h.damage + bonusDmg, h.accurate)]),
-          new WeightedHit(1 - chance, [h]),
-        ]));
+        dist = new AttackDistribution([
+          new HitDistribution([
+            ...standardHitDist.scaleProbability(1 - chance).hits,
+            ...HitDistribution.linear(1.0, bonusDmg, max + bonusDmg).scaleProbability(chance).hits,
+          ]),
+        ]);
       }
 
       if (this.wearing(['Pearl bolts (e)', 'Pearl dragon bolts (e)'])) {
         const chance = 0.06 * kandarinDiaryFactor;
         const divisor = mattrs.includes(MonsterAttribute.FIERY) ? 15 : 20;
         const bonusDmg = Math.trunc(rangedLvl / (zaryte ? divisor - 2 : divisor));
-        dist = dist.transform((h) => new HitDistribution([
-          new WeightedHit(chance, [new Hitsplat(h.damage + bonusDmg, h.accurate)]),
-          new WeightedHit(1 - chance, [h]),
-        ]));
+        dist = new AttackDistribution([
+          new HitDistribution([
+            ...standardHitDist.scaleProbability(1 - chance).hits,
+            ...HitDistribution.linear(1.0, bonusDmg, max + bonusDmg).scaleProbability(chance).hits,
+          ]),
+        ]);
       }
 
       if (this.wearing(['Diamond bolts (e)', 'Diamond dragon bolts (e)'])) {


### PR DESCRIPTION
Opal and pearl bolts were, in effect, rolling for accuracy and damage and *then* rolling for the bolt effect. The result is there was a  higher proportion of hits that were equal to the effect bonus damage because they were inaccurate hits to which the bonus damage was added. Below is an illustration of the result I was getting for opal bolts (pearls were similar):
![image](https://github.com/weirdgloop/osrs-dps-calc/assets/87620453/4b17769f-3539-4921-9eeb-1811af88a9ff)

Hiding inaccurate hits makes it clear that a lot of inaccurate hits were being boosted to 9s:
![image](https://github.com/weirdgloop/osrs-dps-calc/assets/87620453/4a328665-f5f5-4f79-8030-d8c455879faa)

I wanted to make sure that it wasn't like this in-game, so I collected some hit data:
![Opal bolts (e)](https://github.com/weirdgloop/osrs-dps-calc/assets/87620453/a34b07d1-215b-436a-b2b4-07a42a1d69a0)

While it's not enough data for the distribution to be as smooth as I'd like, it's pretty clear that the number of 9s is not significantly higher than other hits. Based on this, I think it's implemented like diamond bolts, where it rolls for the bolt proc and, if successful, bypasses the accuracy roll entirely. I did not test pearl bolts, but I think it's a reasonable assumption that they are both implemented the same way. I changed both to be implemented like diamond bolts are in the calc.

I also changed onyx bolts to boost the max hit by 20% or 32% rather than adding 20% or 32% of the player's visible ranged level to the max hit. The wording in-game and on the wiki only refers to boosting damage by that amount and makes no mention of ranged level, and this Ash tweet supports that as well.
![image](https://github.com/weirdgloop/osrs-dps-calc/assets/87620453/492bdf03-5b8a-457d-b518-f1bd96fd1d07)
