### PR TITLE
ranged salamanders are not accurate

### DIFF
--- a/src/utils.ts
+++ b/src/utils.ts
@@ -560,7 +560,7 @@ export const getCombatStylesForCategory = (style: EquipmentCategory): PlayerComb
     case EquipmentCategory.SALAMANDER:
       ret = [
         { name: 'Scorch', type: 'slash', stance: 'Aggressive' },
-        { name: 'Flare', type: 'ranged', stance: 'Accurate' },
+        { name: 'Flare', type: 'ranged', stance: 'Rapid' },
         { name: 'Blaze', type: 'magic', stance: 'Defensive' },
       ];
       break;


### PR DESCRIPTION
Removes the +3 accuracy bonus from (and fixes the attack speed of) salamanders.

The wiki page was incorrect as well and has been changed.

https://discord.com/channels/177206626514632704/1098698914498101368/1251964210204901617

Closes #366 