### PR TITLE
share: "open in prod" debug button

### DIFF
--- a/src/app/components/ShareModal.tsx
+++ b/src/app/components/ShareModal.tsx
@@ -4,11 +4,11 @@ import { useStore } from '@/state';
 import Modal from '@/app/components/generic/Modal';
 import { generateShortlink } from '@/utils';
 import { toast } from 'react-toastify';
-import { IconClipboardCopy } from '@tabler/icons-react';
+import { IconClipboardCopy, IconExternalLink } from '@tabler/icons-react';
 
 const ShareModal: React.FC = observer(() => {
   const store = useStore();
-  const { ui } = store;
+  const { ui, debug } = store;
   const inputRef = createRef<HTMLInputElement>();
 
   const domain = process.env.NEXT_PUBLIC_SHORTLINK_URL;
@@ -54,11 +54,22 @@ const ShareModal: React.FC = observer(() => {
             <IconClipboardCopy className="w-5" />
             Copy
           </button>
+          {debug && (
+            <a
+              className="form-control flex items-center gap-1 hover:scale-105 no-underline"
+              type="button"
+              href={`https://dps.osrs.wiki?id=${shareId}`}
+              target="_blank"
+            >
+              <IconExternalLink className="w-5" />
+              Prod
+            </a>
+          )}
         </div>
         {error && (
-        <p className="mt-2 text-red-400 dark:text-red-200">
-          There was a problem generating a share link. Please try again.
-        </p>
+          <p className="mt-2 text-red-400 dark:text-red-200">
+            There was a problem generating a share link. Please try again.
+          </p>
         )}
       </div>
     </Modal>


### PR DESCRIPTION
another helper pr, this only appears in debug mode:
![image](https://github.com/weirdgloop/osrs-dps-calc/assets/1868974/e5544de2-ba5a-4dfa-b8d3-e8a7ffb18874)

For comparing behaviours between local and prod