### PR TITLE
warn on empty blowpipe import

### DIFF
--- a/package.json
+++ b/package.json
@@ -15,7 +15,11 @@
     "fmt": "next lint --fix",
     "analyse": "ANALYSE=true next build",
     "test": "jest",
-    "cdn-docker": "yarn build-docker-scraper && docker run --rm -it -v $(pwd)/cdn:/srv/cdn -v $(pwd)/src/lib/EquipmentAliases.ts:/srv/src/lib/EquipmentAliases.ts weirdgloop/osrs-dps-calc:scraper",
+    "cdn-docker-base": "docker run --rm -it -v $(pwd)/scripts:/srv/scripts -v $(pwd)/cdn:/srv/cdn -v $(pwd)/src/lib/EquipmentAliases.ts:/srv/src/lib/EquipmentAliases.ts weirdgloop/osrs-dps-calc:scraper",
+    "cdn-docker": "yarn build-docker-scraper && yarn cdn-docker-base",
+    "cdn-docker-aliases": "yarn cdn-docker-base python generateEquipmentAliases.py",
+    "cdn-docker-equipment": "yarn cdn-docker-base python generateEquipment.py",
+    "cdn-docker-monsters": "yarn cdn-docker-base python generateMonsters.py",
     "cdn-dispatch": "gh workflow run regenerate.yml"
   },
   "dependencies": {

--- a/src/app/home.tsx
+++ b/src/app/home.tsx
@@ -3,7 +3,7 @@
 import type { NextPage } from 'next';
 import MonsterContainer from '@/app/components/monster/MonsterContainer';
 import { Tooltip } from 'react-tooltip';
-import React, { Suspense, useEffect } from 'react';
+import React, { Suspense, useEffect, useMemo } from 'react';
 import { observer } from 'mobx-react-lite';
 import { useStore } from '@/state';
 import { ToastContainer } from 'react-toastify';
@@ -18,6 +18,11 @@ import DebugPanels from '@/app/components/results/DebugPanels';
 import { IconAlertTriangle } from '@tabler/icons-react';
 import NPCVersusPlayerResultsContainer from '@/app/components/results/NPCVersusPlayerResultsContainer';
 import { CalcProvider, useCalc } from '@/worker/CalcWorker';
+import UserIssueType from '@/enums/UserIssueType';
+
+const GLOBAL_ISSUE_TYPES: UserIssueType[] = [
+  UserIssueType.IMPORT_MISSING_DATA,
+];
 
 const Home: NextPage = observer(() => {
   const calc = useCalc();
@@ -91,6 +96,23 @@ const Home: NextPage = observer(() => {
     // eslint-disable-next-line react-hooks/exhaustive-deps
   }, []);
 
+  const globalIssues = useMemo(() => {
+    const issues = store.userIssues.filter((is) => GLOBAL_ISSUE_TYPES.includes(is.type));
+    return (
+      <>
+        {issues.map((is) => (
+          <div
+            key={`${is.loadout || 'global'}/${is.message}`}
+            className="w-full bg-orange-500 text-white px-4 py-1 text-sm border-b border-orange-400 flex items-center gap-1"
+          >
+            <IconAlertTriangle className="text-orange-200" />
+            {`${is.loadout ? `Loadout ${is.loadout}: ` : ''}${is.message}`}
+          </div>
+        ))}
+      </>
+    );
+  }, [store.userIssues]);
+
   return (
     <div>
       {store.prefs.manualMode && (
@@ -103,6 +125,7 @@ const Home: NextPage = observer(() => {
           Manual mode is enabled! Some things may not function correctly. Click here to disable it.
         </button>
       )}
+      {globalIssues}
       <Suspense>
         <InitialLoad />
       </Suspense>

--- a/src/enums/UserIssueType.ts
+++ b/src/enums/UserIssueType.ts
@@ -1,10 +1,12 @@
 enum UserIssueType {
   EQUIPMENT_MISSING_AMMO = 'equipment_slot_ammo_missing',
   EQUIPMENT_WRONG_AMMO = 'equipment_slot_ammo_wrong',
+  EQUIPMENT_WEAPON_EMPTY = 'equipment_slot_weapon_empty',
   EQUIPMENT_SET_EFFECT_UNSUPPORTED = 'equipment_slot_body_unsupported_set_effect',
   SPELL_WRONG_WEAPON = 'spell_wrong_weapon',
   SPELL_WRONG_MONSTER = 'spell_wrong_monster',
   MONSTER_UNIQUE_EFFECTS = 'monster_overall_unique_effects',
+  IMPORT_MISSING_DATA = 'runelite_import_missing_data',
 }
 
 export default UserIssueType;

--- a/src/lib/Equipment.ts
+++ b/src/lib/Equipment.ts
@@ -12,6 +12,9 @@ export type EquipmentBonuses = Pick<Player, 'bonuses' | 'offensive' | 'defensive
  * All available equipment that a player can equip.
  */
 export const availableEquipment = equipment as EquipmentPiece[];
+export const EMPTY_BLOWPIPE = availableEquipment.find(
+  (e) => e.name === 'Toxic blowpipe' && e.version === 'Charged',
+);
 
 export const noStatExceptions = [
   'Castle wars bracelet',

--- a/src/lib/PlayerVsNPCCalc.ts
+++ b/src/lib/PlayerVsNPCCalc.ts
@@ -707,12 +707,8 @@ export default class PlayerVsNPCCalc extends BaseCalc {
    * Get the max hit for this loadout, which is based on the player's current combat style
    */
   private getMaxHit(): MinMax {
-    if (this.player.style.stance !== 'Manual Cast') {
-      const weaponId = this.player.equipment.weapon?.id;
-      const ammoId = this.player.equipment.ammo?.id;
-      if (ammoApplicability(weaponId, ammoId) === AmmoApplicability.INVALID) {
-        return [0, 0];
-      }
+    if (this.fatal) {
+      return [0, 0];
     }
 
     const style = this.player.style.type;
@@ -818,6 +814,10 @@ export default class PlayerVsNPCCalc extends BaseCalc {
   }
 
   private getDistributionImpl(): AttackDistribution {
+    if (this.fatal) {
+      return new AttackDistribution([new HitDistribution([new WeightedHit(1.0, [new Hitsplat(0, false)])])]);
+    }
+
     const mattrs = this.monster.attributes;
     const acc = this.getHitChance();
     const [min, max] = this.getMaxHit();

--- a/src/types/State.ts
+++ b/src/types/State.ts
@@ -6,6 +6,7 @@ import { DetailEntry } from '@/lib/CalcDetails';
 
 export interface UserIssue {
   type: UserIssueType;
+  severity: 'warn' | 'fatal';
   message: string;
   loadout?: string;
 }


### PR DESCRIPTION
Doesn't fully solve the issue, since we still need to fix the import flow to preserve the blowpipe ammo, but this at least prevents users loading empty blowpipes unknowingly and seeing incorrect results.

Closes #293
