### PR TITLE
warn unimplemented spec

### DIFF
--- a/src/app/components/results/PlayerVsNPCResultsContainer.tsx
+++ b/src/app/components/results/PlayerVsNPCResultsContainer.tsx
@@ -4,10 +4,12 @@ import PlayerVsNPCResultsTable from '@/app/components/results/PlayerVsNPCResults
 import { useStore } from '@/state';
 import Toggle from '@/app/components/generic/Toggle';
 import { observer } from 'mobx-react-lite';
+import UserIssueWarning from '@/app/components/generic/UserIssueWarning';
 
 const ResultsContainer = observer(() => {
   const store = useStore();
-  const { prefs } = store;
+  const { prefs, userIssues } = store;
+  const issues = userIssues.filter((i) => i.type.startsWith('pvm_results') && i.loadout === `${store.selectedLoadout + 1}`);
 
   return (
     <div className="grow basis-1/4 md:mt-9 flex flex-col">
@@ -17,8 +19,13 @@ const ResultsContainer = observer(() => {
         <div
           className="px-4 py-3.5 border-b-body-400 bg-body-100 dark:bg-dark-400 dark:border-b-dark-200 border-b md:rounded md:rounded-bl-none md:rounded-br-none flex justify-between items-center"
         >
-          <h2 className="font-serif text-lg tracking-tight font-bold dark:text-white">
+          <h2 className="font-serif text-lg tracking-tight font-bold dark:text-white flex items-center gap-2">
             Results
+            {
+              issues.length > 0 && (
+                <UserIssueWarning className="inline-block" issue={issues[0]} />
+              )
+            }
           </h2>
           <Toggle
             checked={prefs.resultsExpanded}

--- a/src/app/components/results/PlayerVsNPCResultsContainer.tsx
+++ b/src/app/components/results/PlayerVsNPCResultsContainer.tsx
@@ -4,12 +4,10 @@ import PlayerVsNPCResultsTable from '@/app/components/results/PlayerVsNPCResults
 import { useStore } from '@/state';
 import Toggle from '@/app/components/generic/Toggle';
 import { observer } from 'mobx-react-lite';
-import UserIssueWarning from '@/app/components/generic/UserIssueWarning';
 
 const ResultsContainer = observer(() => {
   const store = useStore();
-  const { prefs, userIssues } = store;
-  const issues = userIssues.filter((i) => i.type.startsWith('pvm_results') && i.loadout === `${store.selectedLoadout + 1}`);
+  const { prefs } = store;
 
   return (
     <div className="grow basis-1/4 md:mt-9 flex flex-col">
@@ -21,11 +19,6 @@ const ResultsContainer = observer(() => {
         >
           <h2 className="font-serif text-lg tracking-tight font-bold dark:text-white flex items-center gap-2">
             Results
-            {
-              issues.length > 0 && (
-                <UserIssueWarning className="inline-block" issue={issues[0]} />
-              )
-            }
           </h2>
           <Toggle
             checked={prefs.resultsExpanded}

--- a/src/app/components/results/PlayerVsNPCResultsTable.tsx
+++ b/src/app/components/results/PlayerVsNPCResultsTable.tsx
@@ -7,6 +7,7 @@ import { ACCURACY_PRECISION, DPS_PRECISION, EXPECTED_HIT_PRECISION } from '@/lib
 import { max, min, some } from 'd3-array';
 import { toJS } from 'mobx';
 import { isDefined } from '@/utils';
+import UserIssueType from '@/enums/UserIssueType';
 
 interface IResultRowProps {
   calcKey: keyof Omit<PlayerVsNPCCalculatedLoadout, 'ttkDist'>;
@@ -65,7 +66,7 @@ const ResultRow: React.FC<PropsWithChildren<IResultRowProps>> = observer((props)
     hasResults,
     collapseSpecs,
   } = props;
-  const { calc } = store;
+  const { calc, userIssues } = store;
   const loadouts = toJS(calc.loadouts);
 
   const cells = useMemo(() => {
@@ -78,9 +79,12 @@ const ResultRow: React.FC<PropsWithChildren<IResultRowProps>> = observer((props)
         // results are in, but the weapon has no implemented special attack
         // we colspan on the first entry (specAccuracy) if extended, and just return nothing for the rest
         return (calcKey === 'specAccuracy' || !collapseSpecs)
-          // eslint-disable-next-line react/no-array-index-key
-          ? (<th key={i} rowSpan={5} className="w-28 border-r bg-dark-400 text-dark-200 text-center">N/A</th>)
-          : undefined;
+          ? (
+            // eslint-disable-next-line react/no-array-index-key
+            <th key={i} rowSpan={5} className="w-28 border-r bg-dark-400 text-dark-200 text-center text-xs">
+              {userIssues.find((is) => is.loadout === `${i + 1}` && is.type === UserIssueType.EQUIPMENT_SPEC_UNSUPPORTED) ? 'Not implemented' : 'N/A'}
+            </th>
+          ) : undefined;
       }
 
       return (
@@ -90,7 +94,7 @@ const ResultRow: React.FC<PropsWithChildren<IResultRowProps>> = observer((props)
         </th>
       );
     });
-  }, [loadouts, calcKey, collapseSpecs, hasResults]);
+  }, [loadouts, calcKey, collapseSpecs, hasResults, userIssues]);
 
   return (
     <tr>

--- a/src/enums/UserIssueType.ts
+++ b/src/enums/UserIssueType.ts
@@ -2,6 +2,7 @@ enum UserIssueType {
   EQUIPMENT_MISSING_AMMO = 'equipment_slot_ammo_missing',
   EQUIPMENT_WRONG_AMMO = 'equipment_slot_ammo_wrong',
   EQUIPMENT_SET_EFFECT_UNSUPPORTED = 'equipment_slot_body_unsupported_set_effect',
+  EQUIPMENT_SPEC_UNSUPPORTED = 'equipment_slot_weapon_unsupported_spec',
   SPELL_WRONG_WEAPON = 'spell_wrong_weapon',
   SPELL_WRONG_MONSTER = 'spell_wrong_monster',
   MONSTER_UNIQUE_EFFECTS = 'monster_overall_unique_effects',

--- a/src/enums/UserIssueType.ts
+++ b/src/enums/UserIssueType.ts
@@ -2,7 +2,7 @@ enum UserIssueType {
   EQUIPMENT_MISSING_AMMO = 'equipment_slot_ammo_missing',
   EQUIPMENT_WRONG_AMMO = 'equipment_slot_ammo_wrong',
   EQUIPMENT_SET_EFFECT_UNSUPPORTED = 'equipment_slot_body_unsupported_set_effect',
-  EQUIPMENT_SPEC_UNSUPPORTED = 'equipment_slot_weapon_unsupported_spec',
+  EQUIPMENT_SPEC_UNSUPPORTED = 'pvm_results_weapon_unsupported_spec',
   SPELL_WRONG_WEAPON = 'spell_wrong_weapon',
   SPELL_WRONG_MONSTER = 'spell_wrong_monster',
   MONSTER_UNIQUE_EFFECTS = 'monster_overall_unique_effects',

--- a/src/lib/Equipment.ts
+++ b/src/lib/Equipment.ts
@@ -323,3 +323,29 @@ export const calculateEquipmentBonusesFromGear = (player: Player, monster: Monst
 
   return totals;
 };
+
+/* eslint-disable quote-props */
+export const WEAPON_SPEC_COSTS: { [canonicalName: string]: number } = {
+  'Dragon dagger': 25,
+  "Osmumten's fang": 25,
+  "Osmumten's fang (or)": 25,
+
+  'Dragon halberd': 30,
+  'Crystal halberd': 30,
+
+  'Elder maul': 50,
+  'Dragon warhammer': 50,
+  'Bandos godsword': 50,
+  'Saradomin godsword': 50,
+  'Accursed sceptre': 50,
+  'Accursed sceptre (a)': 50,
+  'Arclight': 50,
+  'Tonalztics of ralos': 50,
+  'Dragon claws': 50,
+  'Voidwaker': 50,
+  'Toxic blowpipe': 50,
+  'Blazing blowpipe': 50,
+
+  'Zaryte crossbow': 75,
+};
+/* eslint-enable quote-props */

--- a/src/lib/PlayerVsNPCCalc.ts
+++ b/src/lib/PlayerVsNPCCalc.ts
@@ -44,11 +44,71 @@ import {
 import { EquipmentCategory } from '@/enums/EquipmentCategory';
 import { DetailKey } from '@/lib/CalcDetails';
 import { Factor, MinMax } from '@/lib/Math';
-import { AmmoApplicability, ammoApplicability } from '@/lib/Equipment';
+import { AmmoApplicability, ammoApplicability, WEAPON_SPEC_COSTS } from '@/lib/Equipment';
 import BaseCalc, { CalcOpts, InternalOpts } from '@/lib/BaseCalc';
 import { scaleMonster, scaleMonsterHpOnly } from '@/lib/MonsterScaling';
 import { CombatStyleType, getRangedDamageType } from '@/types/PlayerCombatStyle';
 import { range, sum } from 'd3-array';
+import { FeatureStatus } from '@/utils';
+
+// https://oldschool.runescape.wiki/w/Category:Weapons_with_Special_attacks
+// Some entries are intentionally omitted as they are not dps-related (e.g. dragon skilling tools, ivandis flail, dbaxe)
+const UNIMPLEMENTED_SPECS: string[] = [
+  'Abyssal bludgeon',
+  'Abyssal dagger',
+  'Abyssal tentacle',
+  'Abyssal whip',
+  'Ancient godsword',
+  'Ancient mace',
+  'Armadyl crossbow',
+  'Armadyl godsword',
+  'Barrelchest anchor',
+  'Blue moon spear',
+  'Bone dagger',
+  'Brine sabre',
+  'Dark bow',
+  'Darklight',
+  'Dawnbringer',
+  "Dinh's bulwark",
+  'Dorgeshuun crossbow',
+  'Dragon 2h sword',
+  'Dragon crossbow',
+  'Dragon hasta',
+  'Dragon knife',
+  'Dragon longsword',
+  'Dragon mace',
+  'Dragon scimitar',
+  'Dragon spear',
+  'Dragon sword',
+  'Dragon thrownaxe',
+  'Dual macuahuitl',
+  'Eclipse atlatl',
+  'Eldritch nightmare staff',
+  'Excalibur',
+  'Granite hammer',
+  'Granite maul',
+  'Heavy ballista',
+  'Light ballista',
+  'Magic comp bow',
+  'Magic longbow',
+  'Magic shortbow',
+  'Magic shortbow (i)',
+  'Rune claws',
+  'Saradomin sword',
+  "Saradomin's blessed sword",
+  'Seercull',
+  'Soulreaper axe',
+  'Staff of balance',
+  'Staff of light',
+  'Staff of the dead',
+  'Toxic staff of the dead',
+  'Ursine chainmace',
+  'Volatile nightmare staff',
+  'Webweaver bow',
+  'Zamorak godsword',
+  'Zamorakian hasta',
+  'Zamorakian spear',
+];
 
 /**
  * Class for computing various player-vs-NPC metrics.
@@ -1479,8 +1539,8 @@ export default class PlayerVsNPCCalc extends BaseCalc {
   }
 
   public getSpecDps(): number {
-    const specCost = PlayerVsNPCCalc.getSpecCost(this.player.equipment.weapon?.name);
-    if (specCost === null) {
+    const specCost = this.getSpecCost();
+    if (!specCost) {
       console.warn(`Expected spec cost for weapon [${this.player.equipment.weapon?.name}] but was not provided`);
       return 0;
     }
@@ -1686,40 +1746,43 @@ export default class PlayerVsNPCCalc extends BaseCalc {
     return Math.trunc(current * bonus / 100);
   };
 
-  static getSpecCost(weaponName: string | null | undefined): number | null {
-    switch (weaponName) {
-      case 'Dragon dagger':
-      case "Osmumten's fang":
-      case "Osmumten's fang (or)":
-        return 25;
+  getSpecCost(): number | undefined {
+    const weaponName = this.player.equipment.weapon?.name;
+    if (!weaponName) {
+      return undefined;
+    }
 
-      case 'Dragon halberd':
-      case 'Crystal halberd':
-        return 30;
+    return WEAPON_SPEC_COSTS[weaponName];
+  }
 
-      case 'Elder maul':
-      case 'Dragon warhammer':
-      case 'Bandos godsword':
-      case 'Saradomin godsword':
-      case 'Accursed sceptre':
-      case 'Accursed sceptre (a)':
-      case 'Arclight':
-      case 'Tonalztics of ralos':
-      case 'Dragon claws':
-      case 'Voidwaker':
-      case 'Toxic blowpipe':
-      case 'Blazing blowpipe':
-        return 50;
+  isSpecSupported(): FeatureStatus {
+    const weaponName = this.player.equipment.weapon?.name;
+    if (!weaponName) {
+      return FeatureStatus.NOT_APPLICABLE;
+    }
 
-      case 'Zaryte crossbow':
-        return 75;
+    if (this.getSpecCost() !== undefined) {
+      return FeatureStatus.IMPLEMENTED;
+    }
+
+    if (UNIMPLEMENTED_SPECS.includes(weaponName)) {
+      return FeatureStatus.UNIMPLEMENTED;
+    }
+
+    return FeatureStatus.NOT_APPLICABLE;
+  }
+
+  getSpecCalc(): PlayerVsNPCCalc | null {
+    switch (this.isSpecSupported()) {
+      case FeatureStatus.IMPLEMENTED:
+      case FeatureStatus.PARTIALLY_IMPLEMENTED:
+        return new PlayerVsNPCCalc(this.player, this.baseMonster, {
+          ...this.opts,
+          usingSpecialAttack: true,
+        });
 
       default:
         return null;
     }
-  }
-
-  static isSpecSupported(weaponName: string | null | undefined) {
-    return PlayerVsNPCCalc.getSpecCost(weaponName) !== null;
   }
 }

--- a/src/lib/PlayerVsNPCCalc.ts
+++ b/src/lib/PlayerVsNPCCalc.ts
@@ -50,6 +50,7 @@ import { scaleMonster, scaleMonsterHpOnly } from '@/lib/MonsterScaling';
 import { CombatStyleType, getRangedDamageType } from '@/types/PlayerCombatStyle';
 import { range, sum } from 'd3-array';
 import { FeatureStatus } from '@/utils';
+import UserIssueType from '@/enums/UserIssueType';
 
 // https://oldschool.runescape.wiki/w/Category:Weapons_with_Special_attacks
 // Some entries are intentionally omitted as they are not dps-related (e.g. dragon skilling tools, ivandis flail, dbaxe)
@@ -118,6 +119,10 @@ export default class PlayerVsNPCCalc extends BaseCalc {
 
   constructor(player: Player, monster: Monster, opts: Partial<CalcOpts> = {}) {
     super(player, monster, opts);
+
+    if (this.isSpecSupported() === FeatureStatus.UNIMPLEMENTED) {
+      this.addIssue(UserIssueType.EQUIPMENT_SPEC_UNSUPPORTED, 'This weapon has a special attack which is not yet supported in the calculator.');
+    }
   }
 
   /**

--- a/src/lib/PlayerVsNPCCalc.ts
+++ b/src/lib/PlayerVsNPCCalc.ts
@@ -121,7 +121,7 @@ export default class PlayerVsNPCCalc extends BaseCalc {
     super(player, monster, opts);
 
     if (this.isSpecSupported() === FeatureStatus.UNIMPLEMENTED) {
-      this.addIssue(UserIssueType.EQUIPMENT_SPEC_UNSUPPORTED, 'This weapon has a special attack which is not yet supported in the calculator.');
+      this.addIssue(UserIssueType.EQUIPMENT_SPEC_UNSUPPORTED, 'This loadout\'s weapon special attack is not yet supported in the calculator.');
     }
   }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -25,6 +25,34 @@ import { PlayerCombatStyle } from '@/types/PlayerCombatStyle';
 import { PartialDeep } from 'type-fest';
 import merge from 'lodash.mergewith';
 
+/**
+ * Can be reused in a number of locations where we partially support a feature
+ * and want to distinguish to users whether that feature is expected, and is implemented.
+ */
+export enum FeatureStatus {
+  /**
+   * The feature is fully implemented and is expected to give accurate and comprehensive results.
+   */
+  IMPLEMENTED,
+
+  /**
+   * The feature is partially but not wholly implemented, and may or may not be accurate.
+   * Example: a special attack that has an increased max hit, and applies damage over time, where only the increased max hit is implemented.
+   */
+  PARTIALLY_IMPLEMENTED,
+
+  /**
+   * The feature is known to exist, but has not been implemented.
+   * Example: A new weapon has been implemented with a unique effect and is selectable in the UI, but it is not yet implemented in the calculator. */
+  UNIMPLEMENTED,
+
+  /**
+   * The feature does not apply to the given conditions.
+   * Example: Querying whether the special attack of a weapon has been implemented, but the weapon does not have a special attack.
+   */
+  NOT_APPLICABLE,
+}
+
 export const classNames = (...classes: string[]) => classes.filter(Boolean).join(' ');
 
 const SHORTLINK_API = 'https://tools.runescape.wiki/osrs-dps/shortlink';

--- a/src/worker/worker.ts
+++ b/src/worker/worker.ts
@@ -3,7 +3,8 @@ import {
   CalcRequestsUnion,
   CalcResponse,
   Handler,
-  TtkRequest, TtkResponse,
+  TtkRequest,
+  TtkResponse,
   WORKER_JSON_REPLACER,
   WORKER_JSON_REVIVER,
   WorkerRequestType,
@@ -31,14 +32,7 @@ const computePvMValues: Handler<WorkerRequestType.COMPUTE_BASIC> = async (data) 
       detailedOutput: calcOpts.detailedOutput,
       disableMonsterScaling: calcOpts.disableMonsterScaling,
     });
-    const specCalc = PlayerVsNPCCalc.isSpecSupported(p.equipment.weapon?.name)
-      ? new PlayerVsNPCCalc(p, monster, {
-        loadoutName,
-        detailedOutput: calcOpts.detailedOutput,
-        disableMonsterScaling: calcOpts.disableMonsterScaling,
-        usingSpecialAttack: true,
-      })
-      : null;
+    const specCalc = calc.getSpecCalc();
 
     res.push({
       npcDefRoll: calc.getNPCDefenceRoll(),


### PR DESCRIPTION
- **new FeatureStatus type for spec support**
- **warn on unimplemented spec**

Added a new FeatureStatus enum for broader support flag usage. Also did a little shuffling so that the parent calc now owns the creation of the spec calc, and uses non-static methods for weapon canonicalization support.