### PR TITLE
worker: log error

### DIFF
--- a/src/worker/worker.ts
+++ b/src/worker/worker.ts
@@ -250,6 +250,7 @@ self.onmessage = async (evt: MessageEvent<string>) => {
     }
   } catch (e: unknown) {
     if (e instanceof Error) {
+      console.error(e);
       res.error = e.message;
     } else {
       res.error = `Unknown error type: ${e}`;


### PR DESCRIPTION
Makes stack traces visible in logs, rather than the stackless error printed by the receiving end