### PR TITLE
Move berserker necklace boost to post-roll

### DIFF
--- a/src/lib/PlayerVsNPCCalc.ts
+++ b/src/lib/PlayerVsNPCCalc.ts
@@ -350,9 +350,6 @@ export default class PlayerVsNPCCalc extends BaseCalc {
       const obsidianBonus = this.trackFactor(DetailKey.MAX_HIT_OBSIDIAN, baseMax, [1, 10]);
       maxHit = this.trackAdd(DetailKey.MAX_HIT_OBSIDIAN, maxHit, obsidianBonus);
     }
-    if (this.isWearingTzhaarWeapon() && this.isWearingBerserkerNecklace()) {
-      maxHit = this.trackFactor(DetailKey.MAX_HIT_BERSERKER, maxHit, [6, 5]);
-    }
     if (this.wearing('Dragon hunter lance') && mattrs.includes(MonsterAttribute.DRAGON)) {
       maxHit = this.trackFactor(DetailKey.MAX_HIT_DRAGONHUNTER, maxHit, [6, 5]);
     }
@@ -1330,6 +1327,10 @@ export default class PlayerVsNPCCalc extends BaseCalc {
       const newMax = this.player.skills.hp;
       const curr = this.player.skills.hp + this.player.boosts.hp;
       dist = dist.scaleDamage(10000 + (newMax - curr) * newMax, 10000);
+    }
+
+    if (this.isUsingMeleeStyle() && this.isWearingBerserkerNecklace() && this.isWearingTzhaarWeapon()) {
+      dist = dist.scaleDamage(6, 5);
     }
 
     // bolt effects


### PR DESCRIPTION
The 20% damage boost from using a berserker necklace with an obsidian weapon is a post-roll effect. I first noticed this on a beta world when I set my max hit to 5, and in 68 recorded hits, did not observe a single 5. 

When using the Tzhaar-ket-om with a berserker necklace at tormented demons, I did not observe any unshielded hits below 39 (i.e., `trunc(33 * 6 / 5)`) in over 500 kills, leading me to believe that it is applied in the same place as Dharok's effect (after the unshielded bonus is added). 