### PR TITLE
import: add version metadata

### DIFF
--- a/src/state.tsx
+++ b/src/state.tsx
@@ -5,7 +5,7 @@ import React, { createContext, useContext } from 'react';
 import { PartialDeep } from 'type-fest';
 import * as localforage from 'localforage';
 import {
-  CalculatedLoadout, Calculator, ImportableData, PlayerVsNPCCalculatedLoadout, Preferences, State, UI, UserIssue,
+  CalculatedLoadout, Calculator, IMPORT_VERSION, ImportableData, PlayerVsNPCCalculatedLoadout, Preferences, State, UI, UserIssue,
 } from '@/types/State';
 import merge from 'lodash.mergewith';
 import {
@@ -141,6 +141,8 @@ export const parseLoadoutsFromImportedData = (data: ImportableData) => data.load
 });
 
 class GlobalState implements State {
+  serializationVersion = IMPORT_VERSION;
+
   monster: Monster = {
     id: 415,
     name: 'Abyssal demon',
@@ -296,6 +298,7 @@ class GlobalState implements State {
    */
   get asImportableData(): ImportableData {
     return {
+      serializationVersion: IMPORT_VERSION,
       loadouts: toJS(this.loadouts),
       monster: toJS(this.monster),
       selectedLoadout: this.selectedLoadout,

--- a/src/types/State.ts
+++ b/src/types/State.ts
@@ -93,10 +93,22 @@ export interface Calculator {
 }
 
 /**
+ * The exported data version, which can be used to perform lazy migrations on load,
+ * if the application changes since the data was written to storage.
+ * This value should be incremented every time {@link ImportableData},
+ * or any of its subproperties, are updated in a non-backwards-compatible manner,
+ * or also in any manner that could affect the migrations required on load.
+ */
+export const IMPORT_VERSION = 1 as const;
+
+/**
  * This is the state that can be exported and imported (through shortlinks).
  * If you change the schema here without taking precautions, you **will** break existing shortlinks.
  */
 export interface ImportableData {
+  // can be any number <= IMPORT_VERSION
+  serializationVersion: number;
+
   loadouts: PartialDeep<Player>[];
   selectedLoadout: number;
 


### PR DESCRIPTION
This is currently unused on load, but may be used in the future if the data exchange format changes.
