### PR TITLE
Fix custom monster toa defence scaling

### DIFF
--- a/src/lib/PlayerVsNPCCalc.ts
+++ b/src/lib/PlayerVsNPCCalc.ts
@@ -164,7 +164,9 @@ export default class PlayerVsNPCCalc extends BaseCalc {
     const statBonus = this.trackAdd(DetailKey.NPC_DEFENCE_STAT_BONUS, defenceStyle ? bonus : 0, 64);
     let defenceRoll = this.trackFactor(DetailKey.NPC_DEFENCE_ROLL_BASE, effectiveLevel, [statBonus, 1]);
 
-    if (TOMBS_OF_AMASCUT_MONSTER_IDS.includes(this.monster.id) && this.monster.inputs.toaInvocationLevel) {
+    const isCustomMonster = this.monster.id === -1;
+
+    if ((TOMBS_OF_AMASCUT_MONSTER_IDS.includes(this.monster.id) || isCustomMonster) && this.monster.inputs.toaInvocationLevel) {
       defenceRoll = this.track(DetailKey.NPC_DEFENCE_ROLL_TOA, Math.trunc(defenceRoll * (250 + this.monster.inputs.toaInvocationLevel) / 250));
     }
 


### PR DESCRIPTION
This changes the defence roll calculation code to check if the monster is _either_ a ToA monster or a custom monster rather than just checking for a ToA monster (which was previously the case and caused custom monsters to ignore raid level scaling). 