### PR TITLE
Fix current HP being set to 150 when monsters have same HP

### DIFF
--- a/src/app/components/monster/MonsterContainer.tsx
+++ b/src/app/components/monster/MonsterContainer.tsx
@@ -129,11 +129,11 @@ const MonsterContainer: React.FC = observer(() => {
   }, [isCustomMonster, monsterJS]);
 
   useEffect(() => {
-    // When display monster HP is changed, update the monster's current HP
-    if (store.monster.inputs.monsterCurrentHp !== displayMonster.skills.hp) {
+    // When display monster HP or NPC ID is changed, update the monster's current HP
+    if (store.monster.inputs.monsterCurrentHp !== displayMonster.skills.hp || store.monster.id !== displayMonster.id) {
       store.updateMonster({ inputs: { monsterCurrentHp: displayMonster.skills.hp } });
     }
-  }, [store, displayMonster.skills.hp]);
+  }, [store, displayMonster.skills.hp, displayMonster.id]);
 
   const tdPhaseOptions = useMemo(() => TD_PHASES.map((s) => ({ label: s })), []);
   const extraMonsterOptions = useMemo(() => {


### PR DESCRIPTION
When switching between two monsters that have the same HP value, the live calc shows a substantially lower average TTK than it should. This is due to the monster's current HP input being set to the default value (150), which can be seen in the calc by using a crossbow with ruby bolts (e) and watching the current HP value. 

This bug stems from the fact that inputs are reset to their initial values in `state.tsx` upon changing monsters, and the monster's current HP input was only being reset to the monster's max HP in `MonsterContainer.tsx` if the max HP changed. This changes it to check for changes to the NPC ID _or_ max HP. 