### PR TITLE
araxxor phases

### DIFF
--- a/src/app/components/monster/MonsterContainer.tsx
+++ b/src/app/components/monster/MonsterContainer.tsx
@@ -26,6 +26,7 @@ import { getCdnImage } from '@/utils';
 import PresetAttributeButton from '@/app/components/monster/PresetAttributeButton';
 import NumberInput from '@/app/components/generic/NumberInput';
 import {
+  ARAXXOR_PHASES,
   GUARDIAN_IDS,
   PARTY_SIZE_REQUIRED_MONSTER_IDS,
   TD_PHASES,
@@ -119,6 +120,28 @@ const MonsterContainer: React.FC = observer(() => {
 
   const isCustomMonster = store.monster.id === -1;
 
+  const phases = useMemo(() => {
+    switch (monster.name) {
+      case 'Tormented Demon':
+        return TD_PHASES;
+
+      case 'Araxxor':
+        return ARAXXOR_PHASES;
+
+      default:
+        return undefined;
+    }
+  }, [monster.name]);
+
+  const phaseOptions = useMemo(() => phases?.map((p) => ({ label: p })), [phases]);
+
+  useEffect(() => {
+    // When display monster name is changed, reset the phase option selection
+    if (phases && !phases?.includes(store.monster.inputs.phase || '')) {
+      store.updateMonster({ inputs: { phase: phases?.[0] } });
+    }
+  }, [store, phases]);
+
   // Don't automatically update the stat inputs if manual editing is on
   const monsterJS = toJS(monster);
   const displayMonster = useMemo(() => {
@@ -135,7 +158,6 @@ const MonsterContainer: React.FC = observer(() => {
     }
   }, [store, displayMonster.skills.hp, displayMonster.id]);
 
-  const tdPhaseOptions = useMemo(() => TD_PHASES.map((s) => ({ label: s })), []);
   const extraMonsterOptions = useMemo(() => {
     // Determine whether we need to show any extra monster option components
     const comps: React.ReactNode[] = [];
@@ -294,7 +316,7 @@ const MonsterContainer: React.FC = observer(() => {
       );
     }
 
-    if (monster.name === 'Tormented Demon') {
+    if (phaseOptions) {
       comps.push(
         <div key="td-phase">
           <h4 className="font-bold font-serif">
@@ -303,11 +325,11 @@ const MonsterContainer: React.FC = observer(() => {
           <div className="mt-2">
             <Select
               id="presets"
-              items={tdPhaseOptions}
-              placeholder={monster.inputs.tormentedDemonPhase}
-              value={tdPhaseOptions.find((o) => o.label === monster.inputs.tormentedDemonPhase)}
+              items={phaseOptions}
+              placeholder={monster.inputs.phase}
+              value={phaseOptions.find((opt) => opt.label === monster.inputs.phase)}
               resetAfterSelect
-              onSelectedItemChange={(v) => store.updateMonster({ inputs: { tormentedDemonPhase: v?.label || undefined } })}
+              onSelectedItemChange={(v) => store.updateMonster({ inputs: { phase: v?.label } })}
             />
           </div>
         </div>,

--- a/src/app/components/monster/MonsterContainer.tsx
+++ b/src/app/components/monster/MonsterContainer.tsx
@@ -1,6 +1,4 @@
-import React, {
-  useEffect, useMemo, useState,
-} from 'react';
+import React, { useEffect, useMemo, useState } from 'react';
 import dagger from '@/public/img/bonuses/dagger.png';
 import scimitar from '@/public/img/bonuses/scimitar.png';
 import warhammer from '@/public/img/bonuses/warhammer.png';
@@ -26,18 +24,14 @@ import { getCdnImage } from '@/utils';
 import PresetAttributeButton from '@/app/components/monster/PresetAttributeButton';
 import NumberInput from '@/app/components/generic/NumberInput';
 import {
-  ARAXXOR_PHASES,
   GUARDIAN_IDS,
+  MONSTER_PHASES_BY_ID,
   PARTY_SIZE_REQUIRED_MONSTER_IDS,
-  TD_PHASES,
   TOMBS_OF_AMASCUT_MONSTER_IDS,
   TOMBS_OF_AMASCUT_PATH_MONSTER_IDS,
 } from '@/lib/constants';
 import {
-  IconChevronDown,
-  IconChevronUp,
-  IconExternalLink,
-  IconShieldQuestion,
+  IconChevronDown, IconChevronUp, IconExternalLink, IconShieldQuestion,
 } from '@tabler/icons-react';
 import { scaleMonster } from '@/lib/MonsterScaling';
 import { Monster, MonsterCombatStyle } from '@/types/Monster';
@@ -120,18 +114,7 @@ const MonsterContainer: React.FC = observer(() => {
 
   const isCustomMonster = store.monster.id === -1;
 
-  const phases = useMemo(() => {
-    switch (monster.name) {
-      case 'Tormented Demon':
-        return TD_PHASES;
-
-      case 'Araxxor':
-        return ARAXXOR_PHASES;
-
-      default:
-        return undefined;
-    }
-  }, [monster.name]);
+  const phases = useMemo(() => MONSTER_PHASES_BY_ID[monster.id], [monster.id]);
 
   const phaseOptions = useMemo(() => phases?.map((p) => ({ label: p })), [phases]);
 

--- a/src/lib/BaseCalc.ts
+++ b/src/lib/BaseCalc.ts
@@ -576,7 +576,7 @@ export default class BaseCalc {
   }
 
   protected tdUnshieldedBonusApplies(): boolean {
-    if (this.monster.name !== 'Tormented Demon' || this.monster.inputs.tormentedDemonPhase !== 'Unshielded') {
+    if (this.monster.name !== 'Tormented Demon' || this.monster.inputs.phase !== 'Unshielded') {
       return false;
     }
 

--- a/src/lib/MonsterScaling.ts
+++ b/src/lib/MonsterScaling.ts
@@ -4,6 +4,7 @@ import applyTobScaling from '@/lib/scaling/TheatreOfBlood';
 import applyToaScaling from '@/lib/scaling/TombsOfAmascut';
 import applyVardScaling from '@/lib/scaling/Vardorvis';
 import applyDefenceReductions from '@/lib/scaling/DefenceReduction';
+import applyMonsterPhases from '@/lib/scaling/Phases';
 
 type MonsterTransformer = (m: Monster) => Monster;
 const ORDER_OF_OPERATIONS: MonsterTransformer[] = [
@@ -11,6 +12,7 @@ const ORDER_OF_OPERATIONS: MonsterTransformer[] = [
   applyTobScaling,
   applyToaScaling,
   applyVardScaling,
+  applyMonsterPhases,
   applyDefenceReductions,
 ];
 

--- a/src/lib/PlayerVsNPCCalc.ts
+++ b/src/lib/PlayerVsNPCCalc.ts
@@ -1026,7 +1026,7 @@ export default class PlayerVsNPCCalc extends BaseCalc {
       return this.track(DetailKey.PLAYER_ACCURACY_FINAL, 1.0);
     }
 
-    if (this.monster.name === 'Tormented Demon' && this.monster.inputs.tormentedDemonPhase !== 'Shielded') {
+    if (this.monster.name === 'Tormented Demon' && this.monster.inputs.phase !== 'Shielded') {
       this.track(DetailKey.PLAYER_ACCURACY_TD, 1.0);
       return this.track(DetailKey.PLAYER_ACCURACY_FINAL, 1.0);
     }

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -393,4 +393,5 @@ export const FLAT_ARMOUR: { [npcId: number]: number } = {
   13029: -2, // grimy lizard
 };
 
-export const TD_PHASES = ['Shielded', 'Shielded (Defenceless)', 'Unshielded'] as const;
+export const TD_PHASES = ['Shielded', 'Shielded (Defenceless)', 'Unshielded'];
+export const ARAXXOR_PHASES = ['Standard', 'Enraged'];

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -393,5 +393,11 @@ export const FLAT_ARMOUR: { [npcId: number]: number } = {
   13029: -2, // grimy lizard
 };
 
+export const MONSTER_PHASES_BY_ID: { [k: number]: string[] } = {};
+export const TD_IDS = [13599, 13600, 13601, 13602, 13603, 13604, 13605, 13606];
 export const TD_PHASES = ['Shielded', 'Shielded (Defenceless)', 'Unshielded'];
+TD_IDS.forEach((id) => { MONSTER_PHASES_BY_ID[id] = TD_PHASES; });
+
+export const ARAXXOR_IDS = [13668];
 export const ARAXXOR_PHASES = ['Standard', 'Enraged'];
+ARAXXOR_IDS.forEach((id) => { MONSTER_PHASES_BY_ID[id] = ARAXXOR_PHASES; });

--- a/src/lib/scaling/Phases.ts
+++ b/src/lib/scaling/Phases.ts
@@ -1,26 +1,22 @@
 import { Monster } from '@/types/Monster';
+import { ARAXXOR_IDS } from '@/lib/constants';
 
 const applyMonsterPhases = (m: Monster): Monster => {
   if (!m.inputs.phase) {
     return m;
   }
 
-  switch (m.name) {
-    case 'Araxxor':
-      if (m.inputs.phase === 'Enraged') {
-        return {
-          ...m,
-          skills: {
-            ...m.skills,
-            def: m.skills.def + 35,
-          },
-        };
-      }
-      return m;
-
-    default:
-      return m;
+  if (ARAXXOR_IDS.includes(m.id) && m.inputs.phase === 'Enraged') {
+    return {
+      ...m,
+      skills: {
+        ...m.skills,
+        def: m.skills.def + 35,
+      },
+    };
   }
+
+  return m;
 };
 
 export default applyMonsterPhases;

--- a/src/lib/scaling/Phases.ts
+++ b/src/lib/scaling/Phases.ts
@@ -1,0 +1,26 @@
+import { Monster } from '@/types/Monster';
+
+const applyMonsterPhases = (m: Monster): Monster => {
+  if (!m.inputs.phase) {
+    return m;
+  }
+
+  switch (m.name) {
+    case 'Araxxor':
+      if (m.inputs.phase === 'Enraged') {
+        return {
+          ...m,
+          skills: {
+            ...m.skills,
+            def: m.skills.def + 35,
+          },
+        };
+      }
+      return m;
+
+    default:
+      return m;
+  }
+};
+
+export default applyMonsterPhases;

--- a/src/state.tsx
+++ b/src/state.tsx
@@ -438,6 +438,15 @@ class GlobalState implements State {
   }
 
   updateImportedData(data: ImportableData) {
+    /* eslint-disable no-fallthrough */
+    switch (data.serializationVersion) {
+      case 1:
+        data.monster.inputs.phase = data.monster.inputs.tormentedDemonPhase;
+
+      default:
+    }
+    /* eslint-enable no-fallthrough */
+
     if (data.monster) {
       let newMonster: PartialDeep<Monster> = {};
 

--- a/src/types/Monster.ts
+++ b/src/types/Monster.ts
@@ -98,6 +98,9 @@ export interface Monster {
       tonalztic: number;
     };
 
+    /** @deprecated use {@link phase} */
     tormentedDemonPhase?: typeof TD_PHASES[number];
+
+    phase?: string;
   }
 }

--- a/src/types/State.ts
+++ b/src/types/State.ts
@@ -99,7 +99,7 @@ export interface Calculator {
  * or any of its subproperties, are updated in a non-backwards-compatible manner,
  * or also in any manner that could affect the migrations required on load.
  */
-export const IMPORT_VERSION = 1 as const;
+export const IMPORT_VERSION = 2 as const;
 
 /**
  * This is the state that can be exported and imported (through shortlinks).


### PR DESCRIPTION
Araxxor gains +35 defence during the final phase of the fight.

This is a generification of the tormented demon phase handling to support arbitrary phases on a per-monster basis. Scaling is handled as a new step in the monster scaling flow.

Previous import data is migrated using the new version metadata.
