### PR TITLE
Fix dark bow regular and spec attacks

### DIFF
--- a/src/lib/HitDist.ts
+++ b/src/lib/HitDist.ts
@@ -362,9 +362,9 @@ export class AttackDistribution {
   }
 }
 
-export function flatLimitTransformer(maximum: number): HitTransformer {
+export function flatLimitTransformer(maximum: number, minimum: number = 0): HitTransformer {
   return (h) => new HitDistribution(
-    [new WeightedHit(1.0, [new Hitsplat(Math.min(h.damage, maximum), h.accurate)])],
+    [new WeightedHit(1.0, [new Hitsplat(Math.max(minimum, Math.min(h.damage, maximum)), h.accurate)])],
   );
 }
 


### PR DESCRIPTION
This PR makes the following changes to the dark bow:

1. Makes it a double-hitting weapon for normal attacks
2. Fixes the spec min hit (which was previously backwards—dragon arrows were getting a min hit of 5 instead of 8)
3. Makes the spec cap at the min and max hits after the damage roll ([Mod Ash tweet](https://x.com/JagexAsh/status/1587017709971202048))