### PR TITLE
repo: use PAT for cdn refresh

### DIFF
--- a/.github/workflows/regenerate.yml
+++ b/.github/workflows/regenerate.yml
@@ -9,12 +9,8 @@ concurrency:
   group: ${{ github.workflow }}
   cancel-in-progress: true
 
-permissions:
-  contents: write
-  pull-requests: write
-
 env:
-  GH_TOKEN: ${{ github.token }}
+  GH_TOKEN: ${{ secrets.CDN_REFRESH_TOKEN }}
 
 jobs:
   run:


### PR DESCRIPTION
This should solve the issue of actions not running when the workflow is run.

> When you use the repository's `GITHUB_TOKEN` to perform tasks, events triggered by the `GITHUB_TOKEN` [...] will not create a new workflow run.
> This prevents you from accidentally creating recursive workflow runs. For example, **if a workflow run pushes code using the repository's `GITHUB_TOKEN`, a new workflow will not run** even when the repository contains a workflow configured to run when push events occur.

https://docs.github.com/en/actions/security-for-github-actions/security-guides/automatic-token-authentication