### PR TITLE
equipment select: return at least one result for matching groups

### DIFF
--- a/src/app/components/player/equipment/EquipmentSelect.tsx
+++ b/src/app/components/player/equipment/EquipmentSelect.tsx
@@ -130,6 +130,7 @@ const EquipmentSelect: React.FC = observer(() => {
       )}
       customFilter={(v) => {
         const remainingVariantGroups: { [k: number]: number[] } = {};
+        const remainingVariantMemberships: { [k: number]: number } = {}; // reverse map
 
         // For each option, add it to a variant group if necessary.
         for (const eqOpt of v) {
@@ -138,6 +139,7 @@ const EquipmentSelect: React.FC = observer(() => {
             const baseId = parseInt(base);
             if (baseId === eqId || vars.includes(eqId)) {
               remainingVariantGroups[baseId] = remainingVariantGroups[baseId] ? [...remainingVariantGroups[baseId], eqId] : [eqId];
+              remainingVariantMemberships[eqId] = baseId;
             }
           }
         }
@@ -146,12 +148,15 @@ const EquipmentSelect: React.FC = observer(() => {
           const eqId = eqOpt.equipment.id;
 
           // This is a base variant, keep it in the list
-          if (Object.keys(equipmentAliases).includes(eqId.toString())) return true;
+          const baseId: number | undefined = remainingVariantMemberships[eqId];
+          if (baseId === eqId) return true;
 
-          for (const group of Object.values(remainingVariantGroups)) {
+          if (baseId !== undefined) {
+            const group = remainingVariantGroups[baseId];
             if (group.includes(eqId)) {
-              // Keep this item in the list if it is the only one left
-              return group.length === 1;
+              // Keep this item in the list if it's the first result,
+              // and its base variant is filtered
+              return group.indexOf(eqId) === 0 && !v.find((o) => o.equipment.id === baseId);
             }
           }
 


### PR DESCRIPTION
In this case, searching for `Araxyte slayer helmet (i)` was not showing any results, since the three variants are all version variants, not name variants. Therefore, all 3 were always present in the matched group, and none were shown.

This PR fixes that by showing the first result of each matching group, preferring the base variant if it is in that group. The result is that we still only see one `Araxyte slayer helmet (i)`, but it still does not appear in searches for `Slayer helmet (i)`.

Current:
![image](https://github.com/user-attachments/assets/3a0826c1-513d-4ac9-af4e-d6183f1e4a97)

Proposed:
![image](https://github.com/user-attachments/assets/d457dc0a-b780-42de-9f91-614c9d0c97e2)
