### PR TITLE
Give yellow keris +25% accuracy in ToA below 25% HP

### DIFF
--- a/src/lib/PlayerVsNPCCalc.ts
+++ b/src/lib/PlayerVsNPCCalc.ts
@@ -249,6 +249,13 @@ export default class PlayerVsNPCCalc extends BaseCalc {
       // https://twitter.com/JagexAsh/status/1704107285381787952
       attackRoll = this.trackFactor(DetailKey.PLAYER_ACCURACY_KERIS, attackRoll, [133, 100]);
     }
+    if (
+      this.wearing('Keris partisan of the sun')
+      && TOMBS_OF_AMASCUT_MONSTER_IDS.includes(this.monster.id)
+      && this.monster.inputs.monsterCurrentHp < Math.floor(this.monster.skills.hp / 4)
+    ) {
+      attackRoll = this.trackFactor(DetailKey.PLAYER_ACCURACY_KERIS, attackRoll, [5, 4]);
+    }
     if (this.wearing(['Blisterwood flail', 'Blisterwood sickle']) && isVampyre(mattrs)) {
       attackRoll = this.trackFactor(DetailKey.PLAYER_ACCURACY_VAMPYREBANE, attackRoll, [21, 20]);
     }
@@ -1922,6 +1929,9 @@ export default class PlayerVsNPCCalc extends BaseCalc {
       return true;
     }
     if (loadout.equipment.weapon?.name.includes('rossbow') && this.wearing(['Ruby bolts (e)', 'Ruby dragon bolts (e)'])) {
+      return true;
+    }
+    if (loadout.equipment.weapon?.name === 'Keris partisan of the sun' && TOMBS_OF_AMASCUT_MONSTER_IDS.includes(monster.id)) {
       return true;
     }
 

--- a/src/lib/PlayerVsNPCCalc.ts
+++ b/src/lib/PlayerVsNPCCalc.ts
@@ -249,11 +249,9 @@ export default class PlayerVsNPCCalc extends BaseCalc {
       // https://twitter.com/JagexAsh/status/1704107285381787952
       attackRoll = this.trackFactor(DetailKey.PLAYER_ACCURACY_KERIS, attackRoll, [133, 100]);
     }
-    if (
-      this.wearing('Keris partisan of the sun')
+    if (this.wearing('Keris partisan of the sun')
       && TOMBS_OF_AMASCUT_MONSTER_IDS.includes(this.monster.id)
-      && this.monster.inputs.monsterCurrentHp < Math.floor(this.monster.skills.hp / 4)
-    ) {
+      && this.monster.inputs.monsterCurrentHp < Math.floor(this.monster.skills.hp / 4)) {
       attackRoll = this.trackFactor(DetailKey.PLAYER_ACCURACY_KERIS, attackRoll, [5, 4]);
     }
     if (this.wearing(['Blisterwood flail', 'Blisterwood sickle']) && isVampyre(mattrs)) {
@@ -1888,6 +1886,13 @@ export default class PlayerVsNPCCalc extends BaseCalc {
       && ['Ruby bolts (e)', 'Ruby dragon bolts (e)'].includes(this.player.equipment.ammo?.name || '')
       && this.monster.inputs.monsterCurrentHp >= 500
       && hp >= 500) {
+      return baseDist;
+    }
+
+    // similarly, only recompute the dist for the yellow keris below 25% hp
+    if (this.wearing('Keris partisan of the sun')
+      && TOMBS_OF_AMASCUT_MONSTER_IDS.includes(this.monster.id)
+      && hp >= Math.floor(this.monster.skills.hp / 4)) {
       return baseDist;
     }
 

--- a/src/lib/PlayerVsNPCCalc.ts
+++ b/src/lib/PlayerVsNPCCalc.ts
@@ -251,7 +251,7 @@ export default class PlayerVsNPCCalc extends BaseCalc {
     }
     if (this.wearing('Keris partisan of the sun')
       && TOMBS_OF_AMASCUT_MONSTER_IDS.includes(this.monster.id)
-      && this.monster.inputs.monsterCurrentHp < Math.floor(this.monster.skills.hp / 4)) {
+      && this.monster.inputs.monsterCurrentHp < Math.trunc(this.monster.skills.hp / 4)) {
       attackRoll = this.trackFactor(DetailKey.PLAYER_ACCURACY_KERIS, attackRoll, [5, 4]);
     }
     if (this.wearing(['Blisterwood flail', 'Blisterwood sickle']) && isVampyre(mattrs)) {
@@ -1892,7 +1892,7 @@ export default class PlayerVsNPCCalc extends BaseCalc {
     // similarly, only recompute the dist for the yellow keris below 25% hp
     if (this.wearing('Keris partisan of the sun')
       && TOMBS_OF_AMASCUT_MONSTER_IDS.includes(this.monster.id)
-      && hp >= Math.floor(this.monster.skills.hp / 4)) {
+      && hp >= Math.trunc(this.monster.skills.hp / 4)) {
       return baseDist;
     }
 
@@ -1936,7 +1936,7 @@ export default class PlayerVsNPCCalc extends BaseCalc {
     if (loadout.equipment.weapon?.name.includes('rossbow') && this.wearing(['Ruby bolts (e)', 'Ruby dragon bolts (e)'])) {
       return true;
     }
-    if (loadout.equipment.weapon?.name === 'Keris partisan of the sun' && TOMBS_OF_AMASCUT_MONSTER_IDS.includes(monster.id)) {
+    if (this.wearing('Keris partisan of the sun') && TOMBS_OF_AMASCUT_MONSTER_IDS.includes(monster.id)) {
       return true;
     }
 


### PR DESCRIPTION
Per the wiki, one of the passive effects of the keris partisan of the sun (yellow keris) is to provide a 25% accuracy increase on targets in ToA that are below 25% of their health. 