### PR TITLE
Add "Player max hit" graph to loadout comparison

### DIFF
--- a/src/app/components/results/LoadoutComparison.tsx
+++ b/src/app/components/results/LoadoutComparison.tsx
@@ -95,6 +95,7 @@ const LoadoutComparison: React.FC = observer(() => {
       { label: 'Player damage-per-second', axisLabel: 'DPS', value: CompareYAxis.PLAYER_DPS },
       { label: 'Player expected hit', axisLabel: 'Hit', value: CompareYAxis.PLAYER_EXPECTED_HIT },
       { label: 'Time-to-kill', axisLabel: 'Seconds', value: CompareYAxis.PLAYER_TTK },
+      { label: 'Player max hit', axisLabel: 'Max hit', value: CompareYAxis.PLAYER_MAX_HIT },
       // {label: 'Damage taken', value: YAxisType.DAMAGE_TAKEN}
     ];
 

--- a/src/lib/Comparator.ts
+++ b/src/lib/Comparator.ts
@@ -29,6 +29,7 @@ export enum CompareYAxis {
   MONSTER_DPS,
   DAMAGE_TAKEN,
   PLAYER_TTK,
+  PLAYER_MAX_HIT,
 }
 
 interface InputSet {
@@ -207,6 +208,10 @@ export default class Comparator {
 
       case CompareYAxis.DAMAGE_TAKEN:
         apply((l) => reverseCalc(l).getAverageDamageTaken().toFixed(DPS_PRECISION));
+        break;
+
+      case CompareYAxis.PLAYER_MAX_HIT:
+        apply((l) => forwardCalc(l).getMax().toString());
         break;
 
       default:


### PR DESCRIPTION
I needed to know the maximum hit for different inferno setups, taking account stat drain over time.
