### PR TITLE
add "start from 0" toggle to y axis (true by default)

### DIFF
--- a/src/lib/Comparator.ts
+++ b/src/lib/Comparator.ts
@@ -43,6 +43,7 @@ export interface CompareResult {
     x: ChartAnnotation[],
     y: ChartAnnotation[],
   },
+  domainMin: number,
   domainMax: number,
 }
 
@@ -252,7 +253,8 @@ export default class Comparator {
     return [];
   }
 
-  public getEntries(): [ChartEntry[], number] {
+  public getEntries(): [ChartEntry[], number, number] {
+    let domainMin: number = Number.MAX_VALUE;
     let domainMax: number = 0;
 
     const res: ChartEntry[] = [];
@@ -263,6 +265,9 @@ export default class Comparator {
         if (f > domainMax) {
           domainMax = f;
         }
+        if (f < domainMin) {
+          domainMin = f;
+        }
       }
 
       res.push({
@@ -271,6 +276,6 @@ export default class Comparator {
       });
     }
 
-    return [res, domainMax];
+    return [res, domainMin, domainMax];
   }
 }

--- a/src/worker/worker.ts
+++ b/src/worker/worker.ts
@@ -95,7 +95,7 @@ const compare: Handler<WorkerRequestType.COMPARE> = async (data) => {
   const { axes, loadouts, monster } = data;
   const comparator = new Comparator(loadouts, monster, axes.x, axes.y);
 
-  const [entries, domainMax] = comparator.getEntries();
+  const [entries, domainMin, domainMax] = comparator.getEntries();
 
   return {
     entries,
@@ -103,6 +103,7 @@ const compare: Handler<WorkerRequestType.COMPARE> = async (data) => {
       x: comparator.getAnnotationsX(),
       y: comparator.getAnnotationsY(),
     },
+    domainMin,
     domainMax,
   };
 };


### PR DESCRIPTION
It can be quite difficult to compare loadouts in the graph if the minimum of the domain is a higher value (e.g. 50-60). This PR allows the user to constrain the Y axis to the minimum value in the domain.

![image](https://github.com/user-attachments/assets/72e584ac-3b35-423b-9ace-17b8134590bc)

![image](https://github.com/user-attachments/assets/1b7792ea-50a9-47c7-b936-2f99dc09c05b)
