### PR TITLE
Increase stat caps to 255 for leagues calcs

### DIFF
--- a/src/app/components/player/skills/SkillInput.tsx
+++ b/src/app/components/player/skills/SkillInput.tsx
@@ -31,7 +31,7 @@ const SkillInput: React.FC<SkillInputProps> = observer((props) => {
                 id={id}
                 required
                 min={1}
-                max={199}
+                max={255}
                 title={`Your current ${name} level`}
                 value={player.skills[field] + player.boosts[field]}
                 onChange={(v) => {
@@ -57,7 +57,7 @@ const SkillInput: React.FC<SkillInputProps> = observer((props) => {
             id={id}
             required
             min={1}
-            max={199}
+            max={255}
             title={`Your base ${name} level`}
             value={player.skills[field]}
             onChange={(v) => {


### PR DESCRIPTION
Allow users to set stats up to 255 for Last Stand relic calculations (and for WGS, I suppose)