### PR TITLE
Show attack speed in results

### DIFF
--- a/src/app/components/results/PlayerVsNPCResultsTable.tsx
+++ b/src/app/components/results/PlayerVsNPCResultsTable.tsx
@@ -3,7 +3,9 @@ import { observer } from 'mobx-react-lite';
 import { useStore } from '@/state';
 import { PlayerVsNPCCalculatedLoadout } from '@/types/State';
 import Spinner from '@/app/components/Spinner';
-import { ACCURACY_PRECISION, DPS_PRECISION, EXPECTED_HIT_PRECISION } from '@/lib/constants';
+import {
+  ACCURACY_PRECISION, ATTACK_SPEED_PRECISION, DPS_PRECISION, EXPECTED_HIT_PRECISION,
+} from '@/lib/constants';
 import { max, min, some } from 'd3-array';
 import { toJS } from 'mobx';
 import { isDefined } from '@/utils';
@@ -37,6 +39,8 @@ const calcKeyToString = (value: number, calcKey: keyof PlayerVsNPCCalculatedLoad
       return value === 0
         ? '-----'
         : `${value.toFixed(1)}s`;
+    case 'attackSpeed':
+      return value.toFixed(ATTACK_SPEED_PRECISION);
     default:
       return `${value}`;
   }
@@ -149,6 +153,11 @@ const PlayerVsNPCResultsTable: React.FC = observer(() => {
         <ResultRow calcKey="accuracy" title="How accurate you are against the monster" hasResults={hasResults}>
           Accuracy
         </ResultRow>
+        {resultsExpanded && (
+          <ResultRow calcKey="attackSpeed" title="The attack speed of the weapon in ticks" hasResults={hasResults}>
+            Attack Speed
+          </ResultRow>
+        )}
         {!resultsExpanded && (
           <ResultRow calcKey="specExpected" title="The expected hit that the special attack will deal to the monster per use, including misses" hasResults={hasResults} collapseSpecs={resultsExpanded}>
             Spec expected hit

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -358,6 +358,7 @@ export const VARDORVIS_IDS = [12223, 12224, 12228, 12425, 12426, 13656];
 export const ACCURACY_PRECISION = 2;
 export const DPS_PRECISION = 3;
 export const EXPECTED_HIT_PRECISION = 1;
+export const ATTACK_SPEED_PRECISION = 0;
 
 export const AUTOCAST_STANCES: CombatStyleStance[] = ['Autocast', 'Defensive Autocast'];
 export const CAST_STANCES: CombatStyleStance[] = [...AUTOCAST_STANCES, 'Manual Cast'];

--- a/src/types/State.ts
+++ b/src/types/State.ts
@@ -67,6 +67,7 @@ export interface PlayerVsNPCCalculatedLoadout extends CalculatedLoadout {
   ttk?: number,
   hitDist?: ChartEntry[],
   ttkDist?: Map<number, number>,
+  attackSpeed?: number,
 
   specAccuracy?: number,
   specMaxHit?: number,

--- a/src/worker/worker.ts
+++ b/src/worker/worker.ts
@@ -45,6 +45,7 @@ const computePvMValues: Handler<WorkerRequestType.COMPUTE_BASIC> = async (data) 
       hitDist: calc.getHistogram(calcOpts.hitDistHideMisses),
       details: calc.details,
       userIssues: calc.userIssues,
+      attackSpeed: calc.getExpectedAttackSpeed(),
 
       specAccuracy: specCalc?.getHitChance(),
       specMaxHit: specCalc?.getDisplayMax(),


### PR DESCRIPTION
The combat masteries affect attack speed which can make comparing loadouts more difficult. This will show the weapon attack speed when the results are expanded.