### PR TITLE
Fix ToA scaling bug for team sizes > 3

### DIFF
--- a/src/lib/scaling/TombsOfAmascut.ts
+++ b/src/lib/scaling/TombsOfAmascut.ts
@@ -25,7 +25,7 @@ const applyToaScaling = (m: Monster): Monster => {
 
   const partySize = Math.min(8, Math.max(1, inputs.partySize));
   if (partySize >= 2) {
-    let partyFactor = 9 * (partySize === 3 ? 2 : 1);
+    let partyFactor = 9 * (partySize >= 3 ? 2 : 1);
     if (partySize >= 4) {
       partyFactor += 6 * (partySize - 3);
     }


### PR DESCRIPTION
Previously, the party size modifier was too low for any size higher than 3 because this line
`let partyFactor = 9 * (partySize === 3 ? 2 : 1);`
was only multiplying 9 by 2 when the party size was exactly equal to 3, rather than when it was at least 3. 

I verified the results with random youtube VODs of group raids (don't have the links on-hand but can find them again if needed).