### PR TITLE
Changed attack speed of Twinflame Staffo to 6 when casting.

### DIFF
--- a/src/lib/Equipment.ts
+++ b/src/lib/Equipment.ts
@@ -244,7 +244,7 @@ export const calculateAttackSpeed = (player: Player, monster: Monster): number =
       attackSpeed = 4;
     } else if (player.equipment.weapon?.name === 'Twinflame staff') {
       attackSpeed = 6;
-    }else{
+    } else {
       attackSpeed = 5;
     }
   }

--- a/src/lib/Equipment.ts
+++ b/src/lib/Equipment.ts
@@ -242,7 +242,9 @@ export const calculateAttackSpeed = (player: Player, monster: Monster): number =
       && player.spell?.spellbook === 'standard'
       && player.style.stance !== 'Manual Cast') {
       attackSpeed = 4;
-    } else {
+    } else if (player.equipment.weapon?.name === 'Twinflame staff') {
+	  attackSpeed = 6;
+ 	  } else {
       attackSpeed = 5;
     }
   }

--- a/src/lib/Equipment.ts
+++ b/src/lib/Equipment.ts
@@ -243,8 +243,8 @@ export const calculateAttackSpeed = (player: Player, monster: Monster): number =
       && player.style.stance !== 'Manual Cast') {
       attackSpeed = 4;
     } else if (player.equipment.weapon?.name === 'Twinflame staff') {
-	    attackSpeed = 6;
- 	  } else {
+      attackSpeed = 6;
+    }else{
       attackSpeed = 5;
     }
   }

--- a/src/lib/Equipment.ts
+++ b/src/lib/Equipment.ts
@@ -243,7 +243,7 @@ export const calculateAttackSpeed = (player: Player, monster: Monster): number =
       && player.style.stance !== 'Manual Cast') {
       attackSpeed = 4;
     } else if (player.equipment.weapon?.name === 'Twinflame staff') {
-	  attackSpeed = 6;
+	    attackSpeed = 6;
  	  } else {
       attackSpeed = 5;
     }

--- a/src/lib/PlayerVsNPCCalc.ts
+++ b/src/lib/PlayerVsNPCCalc.ts
@@ -1335,14 +1335,17 @@ export default class PlayerVsNPCCalc extends BaseCalc {
     }
 
     if (this.player.style.type === 'magic'
-      && this.wearing('Twinflame staff')
-      && ['Bolt', 'Blast', 'Wave'].includes(this.player.spell?.name ?? '')) {
-      dist = dist.transform(
-        (h) => HitDistribution.single(1.0, [
-          new Hitsplat(h.damage),
-          new Hitsplat(Math.trunc(h.damage * 4 / 10)),
-        ]),
-      );
+      && this.wearing('Twinflame staff')) {
+        if (this.player.spell?.name.toLowerCase().includes('bolt')
+          || this.player.spell?.name.toLowerCase().includes('blast')
+          || this.player.spell?.name.toLowerCase().includes('wave')) {
+            dist = dist.transform(
+              (h) => HitDistribution.single(1.0, [
+                new Hitsplat(h.damage),
+                new Hitsplat(Math.trunc(h.damage * 4 / 10)),
+              ]),
+            );
+        }
     }
 
     if (this.player.style.type === 'magic' && this.isWearingAhrims()) {


### PR DESCRIPTION
Attack speed for Twinflame staff needs to be 6
when casting.  I have edited the casting code
where harm staff 4 tick is handled to make
the attack speed 6 with Twinflame staff.