### PR TITLE
Add some of the unimplemented specs

### DIFF
--- a/src/lib/BaseCalc.ts
+++ b/src/lib/BaseCalc.ts
@@ -618,6 +618,10 @@ export default class BaseCalc {
     }
   }
 
+  protected isAmmoInvalid(): boolean {
+    return ammoApplicability(this.player.equipment.weapon?.id, this.player.equipment.ammo?.id) === AmmoApplicability.INVALID;
+  }
+
   protected addIssue(type: UserIssueType, message: string) {
     this.userIssues.push({ type, message, loadout: this.opts.loadoutName });
   }
@@ -664,7 +668,7 @@ export default class BaseCalc {
       };
     }
 
-    if (this.player.style.stance !== 'Manual Cast' && ammoApplicability(eq.weapon?.id, eq.ammo?.id) === AmmoApplicability.INVALID) {
+    if (this.player.style.stance !== 'Manual Cast' && this.isAmmoInvalid()) {
       if (eq.ammo?.name) {
         this.addIssue(UserIssueType.EQUIPMENT_WRONG_AMMO, 'This ammo does not work with your current weapon.');
       } else {

--- a/src/lib/Equipment.ts
+++ b/src/lib/Equipment.ts
@@ -368,10 +368,13 @@ export const calculateEquipmentBonusesFromGear = (player: Player, monster: Monst
 export const WEAPON_SPEC_COSTS: { [canonicalName: string]: number } = {
   'Abyssal dagger': 25,
   'Dragon dagger': 25,
+  'Dragon longsword': 25,
+  'Dragon mace': 25,
   "Osmumten's fang": 25,
   "Osmumten's fang (or)": 25,
   'Dual macuahuitl': 25,
   'Scorching bow': 25,
+  'Dragon knife': 25,
   'Purging staff': 25,
 
   'Dawnbringer': 30,
@@ -381,6 +384,8 @@ export const WEAPON_SPEC_COSTS: { [canonicalName: string]: number } = {
 
   'Magic longbow': 35,
   'Magic comp bow': 35,
+
+  'Dragon sword': 40,
 
   'Elder maul': 50,
   'Dragon warhammer': 50,
@@ -401,12 +406,21 @@ export const WEAPON_SPEC_COSTS: { [canonicalName: string]: number } = {
   'Armadyl godsword': 50,
   'Zamorak godsword': 50,
   'Abyssal bludgeon': 50,
+  'Abyssal whip': 50,
 
   'Magic shortbow': 55,
   'Dark bow': 55,
   'Eldritch nightmare staff': 55,
   'Volatile nightmare staff': 55,
+  'Dragon scimitar': 55,
+
+  'Heavy ballista': 65,
+  'Light ballista': 65,
+  "Saradomin's blessed sword": 65,
 
   'Zaryte crossbow': 75,
+
+  'Saradomin sword': 100,
+  'Seercull': 100,
 };
 /* eslint-enable quote-props */


### PR DESCRIPTION
Added all of the unimplemented specs that were simple to implement. In the process, I found a bug with the magic longbow and (newly implemented) seercull specs that transformed all hits to 1s even when using invalid ammo, which I fixed. I also added an `isAmmoInvalid()` method to `BaseCalc.ts` to remove some duplicated code related to that.