### PR TITLE
Sort Gauntlet Equipment

### DIFF
--- a/src/app/components/player/equipment/EquipmentSelect.tsx
+++ b/src/app/components/player/equipment/EquipmentSelect.tsx
@@ -5,8 +5,14 @@ import { getCdnImage, isDefined } from '@/utils';
 import { EquipmentPiece } from '@/types/Player';
 import LazyImage from '@/app/components/generic/LazyImage';
 import { cross } from 'd3-array';
-import { availableEquipment, equipmentAliases, noStatExceptions } from '@/lib/Equipment';
-import { BLOWPIPE_IDS } from '@/lib/constants';
+import {
+  availableEquipment,
+  CORRUPTED_GAUNTLET_EQUIPMENT_IDS,
+  equipmentAliases,
+  GAUNTLET_EQUIPMENT_IDS,
+  noStatExceptions,
+} from '@/lib/Equipment';
+import { BLOWPIPE_IDS, GAUNTLET_MONSTER_IDS, CORRUPTED_GAUNTLET_MONSTER_IDS } from '@/lib/constants';
 import Combobox from '../../generic/Combobox';
 
 interface EquipmentOption {
@@ -91,9 +97,35 @@ const EquipmentSelect: React.FC = observer(() => {
         },
       });
     });
+    if (GAUNTLET_MONSTER_IDS.includes(store.monster.id)) {
+      return entries.sort((a, b) => {
+        const aPriority = GAUNTLET_EQUIPMENT_IDS.includes(a.equipment.id);
+        const bPriority = GAUNTLET_EQUIPMENT_IDS.includes(b.equipment.id);
+        if (aPriority && !bPriority) return -1;
+        if (!aPriority && bPriority) return 1;
 
-    return entries;
-  }, []);
+        return a.label.localeCompare(b.label);
+      });
+    }
+    if (CORRUPTED_GAUNTLET_MONSTER_IDS.includes(store.monster.id)) {
+      return entries.sort((a, b) => {
+        const aPriority = CORRUPTED_GAUNTLET_EQUIPMENT_IDS.includes(a.equipment.id);
+        const bPriority = CORRUPTED_GAUNTLET_EQUIPMENT_IDS.includes(b.equipment.id);
+        if (aPriority && !bPriority) return -1;
+        if (!aPriority && bPriority) return 1;
+
+        return a.label.localeCompare(b.label);
+      });
+    }
+    return entries.sort((a, b) => {
+      const aPriority = GAUNTLET_EQUIPMENT_IDS.includes(a.equipment.id) || CORRUPTED_GAUNTLET_EQUIPMENT_IDS.includes(a.equipment.id);
+      const bPriority = GAUNTLET_EQUIPMENT_IDS.includes(b.equipment.id) || CORRUPTED_GAUNTLET_EQUIPMENT_IDS.includes(b.equipment.id);
+      if (aPriority && !bPriority) return 1;
+      if (!aPriority && bPriority) return -1;
+
+      return a.label.localeCompare(b.label);
+    });
+  }, [store.monster.id]);
 
   return (
     <Combobox<EquipmentOption>

--- a/src/lib/Equipment.ts
+++ b/src/lib/Equipment.ts
@@ -424,3 +424,53 @@ export const WEAPON_SPEC_COSTS: { [canonicalName: string]: number } = {
   'Seercull': 100,
 };
 /* eslint-enable quote-props */
+
+export const GAUNTLET_EQUIPMENT_IDS = [
+  23861, // Crystal sceptre
+  23862, // Crystal axe (The Gauntlet)
+  23863, // Crystal pickaxe (The Gauntlet)
+  23864, // Crystal harpoon (The Gauntlet)
+  23886, // Crystal helm (basic)
+  23887, // Crystal helm (attuned)
+  23888, // Crystal helm (perfected)
+  23889, // Crystal body (basic)
+  23890, // Crystal body (attuned)
+  23891, // Crystal body (perfected)
+  23892, // Crystal legs (basic)
+  23893, // Crystal legs (attuned)
+  23894, // Crystal legs (perfected)
+  23895, // Crystal halberd (basic)
+  23896, // Crystal halberd (attuned)
+  23897, // Crystal halberd (perfected)
+  23898, // Crystal staff (basic)
+  23899, // Crystal staff (attuned)
+  23900, // Crystal staff (perfected)
+  23901, // Crystal bow (basic)
+  23902, // Crystal bow (attuned)
+  23903, // Crystal bow (perfected)
+];
+
+export const CORRUPTED_GAUNTLET_EQUIPMENT_IDS = [
+  23820, // Corrupted sceptre
+  23821, // Corrupted axe
+  23822, // Corrupted pickaxe
+  23823, // Corrupted harpoon
+  23840, // Corrupted helm (basic)
+  23841, // Corrupted helm (attuned)
+  23842, // Corrupted helm (perfected)
+  23843, // Corrupted body (basic)
+  23844, // Corrupted body (attuned)
+  23845, // Corrupted body (perfected)
+  23846, // Corrupted legs (basic)
+  23847, // Corrupted legs (attuned)
+  23848, // Corrupted legs (perfected)
+  23849, // Corrupted halberd (basic)
+  23850, // Corrupted halberd (attuned)
+  23851, // Corrupted halberd (perfected)
+  23852, // Corrupted staff (basic)
+  23853, // Corrupted staff (attuned)
+  23854, // Corrupted staff (perfected)
+  23855, // Corrupted bow (basic)
+  23856, // Corrupted bow (attuned)
+  23857, // Corrupted bow (perfected)
+];

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -137,6 +137,38 @@ export const TOB_EM_MONSTER_IDS = [
   10837, 10841, 10842, 10843, 10844, 10845, // verzik web + nylos
 ];
 
+/** IDs of monsters that are present in The Gauntlet.
+ * Used to sort equipment
+ */
+export const GAUNTLET_MONSTER_IDS = [
+  9021, // Crystalline Hunllef
+  9026, // Crystalline Rat
+  9027, // Crystalline Spider
+  9028, // Crystalline Bat
+  9029, // Crystalline Unicorn
+  9030, // Crystalline Scorpion
+  9031, // Crystalline Wolf
+  9032, // Crystalline Bear
+  9033, // Crystalline Dragon
+  9034, // Crystalline Dark Beast
+];
+
+/** IDs of monsters that are present in The Corrupted Gauntlet.
+ * Used to sort equipment
+ */
+export const CORRUPTED_GAUNTLET_MONSTER_IDS = [
+  9035, // Corrupted Hunllef
+  9040, // Corrupted Rat
+  9041, // Corrupted Spider
+  9042, // Corrupted Bat
+  9043, // Corrupted Unicorn
+  9044, // Corrupted Scorpion
+  9045, // Corrupted Wolf
+  9046, // Corrupted Bear
+  9047, // Corrupted Dragon
+  9048, // Corrupted Dark Beast
+];
+
 /**
  * IDs of Tekton from the Chambers of Xeric.
  * Separated due to different defence scaling rules.


### PR DESCRIPTION
When a monster not from the (Corrupted) Gauntlet is selected equipment from the gaunlet is deprioritized. 
![image](https://github.com/user-attachments/assets/4b6f4447-fa61-4997-a7fe-f379b1d7b307)

When a monster from the Gauntlet relevant equipment is prioritized. 
![image](https://github.com/user-attachments/assets/6a4ea0cc-535e-4fcd-b523-ebe5db49cdd1)

Likewise with the Corrupted Gauntlet
![image](https://github.com/user-attachments/assets/360227b2-fa9c-4293-95cc-9c4fb3c9a499)
