### PR TITLE
Include damage reductions in NPC max hit display

### DIFF
--- a/src/worker/worker.ts
+++ b/src/worker/worker.ts
@@ -76,7 +76,7 @@ const computeMvPValues: Handler<WorkerRequestType.COMPUTE_REVERSE> = async (data
     });
     res.push({
       npcMaxAttackRoll: calc.getNPCMaxAttackRoll(),
-      npcMaxHit: calc.getNPCMaxHit(),
+      npcMaxHit: calc.getDistribution().getMax(),
       npcDps: calc.getDps(),
       npcAccuracy: calc.getHitChance(),
       playerDefRoll: calc.getPlayerDefenceRoll(),


### PR DESCRIPTION
The displayed NPC max hit previously did not include damage reductions such as the justiciar set effect or Dinh's bulwark on block (even though they were accounted for in the DPS calculation).