### PR TITLE
Add 100% freeze rate for Maiden Crabs

### DIFF
--- a/src/lib/PlayerVsNPCCalc.ts
+++ b/src/lib/PlayerVsNPCCalc.ts
@@ -44,6 +44,7 @@ import {
   UNDERWATER_MONSTERS,
   USES_DEFENCE_LEVEL_FOR_MAGIC_DEFENCE_NPC_IDS,
   VERZIK_P1_IDS,
+  MAIDEN_CRAB_IDS,
 } from '@/lib/constants';
 import { EquipmentCategory } from '@/enums/EquipmentCategory';
 import { DetailKey } from '@/lib/CalcDetails';
@@ -1133,6 +1134,15 @@ export default class PlayerVsNPCCalc extends BaseCalc {
           DetailKey.PLAYER_ACCURACY_FANG,
           BaseCalc.getFangAccuracyRoll(atk, def),
         );
+      }
+    }
+    
+    if (this.player.spell?.name.includes('Ice') && MAIDEN_CRAB_IDS.includes(this.monster.id)) {
+      const guaranteedFreezeRoll = (this.player.skills.magic + 9) * 204;
+      const playerMagicRoll = this.getPlayerMaxMagicAttackRoll();
+ 
+      if (playerMagicRoll > guaranteedFreezeRoll) {
+        return 1.0;
       }
     }
 

--- a/src/lib/constants.ts
+++ b/src/lib/constants.ts
@@ -475,3 +475,5 @@ HUEYCOATL_PHASE_IDS.forEach((id) => { MONSTER_PHASES_BY_ID[id] = HUEYCOATL_PHASE
 
 export const ROYAL_TITANS_PHASES = ['In Melee Range', 'Out of Melee Range'];
 TITAN_BOSS_IDS.forEach((id) => { MONSTER_PHASES_BY_ID[id] = ROYAL_TITANS_PHASES; });
+
+export const MAIDEN_CRAB_IDS = [10820, 8366, 10828];


### PR DESCRIPTION
Update the accuracy calculations for ice spells on Maiden crabs [[wiki reference](https://oldschool.runescape.wiki/w/Nylocas_Matomenos#Freezing_Nylocas_Matomenos)]. 