### PR TITLE
Update equipment filter to check every value is zero

### DIFF
--- a/src/app/components/player/equipment/EquipmentSelect.tsx
+++ b/src/app/components/player/equipment/EquipmentSelect.tsx
@@ -46,9 +46,9 @@ const EquipmentSelect: React.FC = observer(() => {
     for (const v of availableEquipment.filter((eq) => {
       if (
         (
-          (Object.values(eq.bonuses).reduce((a, b) => a + b, 0) === 0)
-          && (Object.values(eq.offensive).reduce((a, b) => a + b, 0) === 0)
-          && (Object.values(eq.defensive).reduce((a, b) => a + b, 0) === 0)
+          (Object.values(eq.bonuses).every((val) => val === 0))
+          && (Object.values(eq.offensive).every((val) => val === 0))
+          && (Object.values(eq.defensive).every((val) => val === 0))
           && (eq.speed === 4 || eq.speed <= 0)
           && !noStatExceptions.includes(eq.name)
         )


### PR DESCRIPTION
Currently this checks the sum of values is non-zero. Something like the silly jester boots
```
{
    "stab": 0,
    "slash": 0,
    "crush": 0,
    "magic": 5,
    "ranged": -5
}
```
are inadvertently filtered out due to the -5 cancelling the +5. With this change every stat is checked to be non-zero, rather than the sum being non-zero.