### PR TITLE
Add a max hit field to custom monsters

### DIFF
--- a/src/app/components/monster/MonsterContainer.tsx
+++ b/src/app/components/monster/MonsterContainer.tsx
@@ -177,6 +177,20 @@ const MonsterContainer: React.FC = observer(() => {
             />
           </div>
         </div>,
+        <div key="max-hit">
+          <h4 className="font-bold font-serif">
+            Max hit
+          </h4>
+          <div className="mt-2">
+            <NumberInput
+              value={monster.maxHit ? monster.maxHit : 0}
+              min={0}
+              max={200}
+              onChange={(h) => store.updateMonster({ maxHit: h })}
+              required
+            />
+          </div>
+        </div>,
         <div key="monster-size">
           <h4 className="font-bold font-serif">
             Size (tiles)


### PR DESCRIPTION
Added a max hit box to the Monster Settings block of a custom NPC. I think this is useful for cases where NPCs have magic max hits that don't line up with their stats, or if someone wants to calc damage taken when there's damage reduction from overhead prayers (though a proper overhead feature is of course better—this would just be a stopgap). 