### PR TITLE
Correct order of operations for magic demonbane

### DIFF
--- a/src/lib/BaseCalc.ts
+++ b/src/lib/BaseCalc.ts
@@ -636,22 +636,30 @@ export default class BaseCalc {
     this.userIssues.push({ type, message, loadout: this.opts.loadoutName });
   }
 
+  protected demonbaneVulnerability(): number {
+    if (this.monster.id === -1 && this.monster.inputs.demonbaneVulnerability !== undefined) {
+      return this.monster.inputs.demonbaneVulnerability;
+    } if (this.monster.name === 'Duke Sucellus') {
+      return 70;
+    } if (this.monster.name === 'Yama') {
+      return 120;
+    } if (this.monster.name === 'Void Flare') {
+      return 200;
+    }
+
+    return 100;
+  }
+
   private sanitizeInputs() {
     const eq = this.player.equipment;
 
     if (this.monster.attributes.includes(MonsterAttribute.DEMON)) {
       // make sure demonbane effectiveness is set and uses the right value
-      let demonbaneEffectiveness: number = 100;
-      if (this.monster.id === -1 && this.monster.inputs.demonbaneVulnerability !== undefined) {
-        demonbaneEffectiveness = this.monster.inputs.demonbaneVulnerability;
-      } else if (this.monster.name === 'Duke Sucellus') {
-        demonbaneEffectiveness = 70;
-      }
       this.monster = {
         ...this.monster,
         inputs: {
           ...this.monster.inputs,
-          demonbaneVulnerability: demonbaneEffectiveness,
+          demonbaneVulnerability: this.demonbaneVulnerability(),
         },
       };
     }

--- a/src/lib/PlayerVsNPCCalc.ts
+++ b/src/lib/PlayerVsNPCCalc.ts
@@ -1466,8 +1466,13 @@ export default class PlayerVsNPCCalc extends BaseCalc {
     }
 
     if (this.player.buffs.markOfDarknessSpell && this.player.spell?.name.includes('Demonbane') && mattrs.includes(MonsterAttribute.DEMON)) {
-      const demonbaneFactor = this.demonbaneFactor(this.wearing('Purging staff') ? 50 : 25);
-      dist = dist.transform((h) => HitDistribution.single(1.0, [new Hitsplat(h.damage + Math.trunc(h.damage * demonbaneFactor[0] / demonbaneFactor[1]))]));
+      const demonbaneFactor = this.wearing('Purging staff') ? 50 : 25;
+      dist = dist.transform(
+        (h) => HitDistribution.single(1.0, [new Hitsplat(
+          h.damage + Math.trunc(Math.trunc(h.damage * demonbaneFactor / 100) * this.demonbaneVulnerability() / 100),
+          h.accurate,
+        )]),
+      );
     }
 
     if (this.player.style.type === 'magic' && this.isWearingAhrims()) {


### PR DESCRIPTION
From in-game testing, it appears that demonbane vulnerability is applied separately _after_ the damage boost from Mark of Darkness (+ purging staff if applicable) is calculated, resulting in some max hits that are one lower than the previously expected value due to rounding. 

Here are the data I have (all of which match with the implementation in this PR):

- Base max hit of 30 -> 44 with MoD (no purging staff) on 200% vulnerability (expected is 45)

- Base max hit of 31 -> 45 with MoD (no purging staff on 200% vulnerability (expected is 46)

- Base max hit of 33 ->
  - 52 with MoD + purging staff on 120% vulnerability (matches expectation)
  - 65 with MoD + purging staff on 200% vulnerability (expected is 66)
  - 49 with MoD (no purging staff) on 200% vulnerability (matches expectation)

- Base max hit of 34 -> 68 with MoD + purging staff on 200% vulnerability

- Base max hit of 37 -> 58 with MoD + purging staff on 120% vulnerability (expected is 59)

- Base max hit of 39 -> 77 with MoD + purging staff on 200% vulnerability (expected is 78)

- Base max hit of 41 -> 81 with MoD + purging staff on 200% vulnerability (expected is 82)

I also created a function for determining demonbane vulnerability and updated it with the two new NPCs (Yama and Void Flare). This is probably better done using a monster infobox param that gets pulled into `monsters.json`, but for now that doesn't exist, and there are not a lot of NPCs with vulnerabilities that aren't 100%.