### PR TITLE
Remove TD damage reduction for unshielded

### DIFF
--- a/src/lib/PlayerVsNPCCalc.ts
+++ b/src/lib/PlayerVsNPCCalc.ts
@@ -1697,7 +1697,7 @@ export default class PlayerVsNPCCalc extends BaseCalc {
       );
     }
     if (this.monster.name === 'Tormented Demon') {
-      if (!this.tdUnshieldedBonusApplies() && !this.isUsingDemonbane() && !this.isUsingAbyssal()) {
+      if (this.monster.inputs.phase !== 'Unshielded' && !this.isUsingDemonbane() && !this.isUsingAbyssal()) {
         // 20% damage reduction when not using demonbane or abyssal
         // todo floor of 1?
         dist = dist.transform(multiplyTransformer(4, 5, 1));


### PR DESCRIPTION
Per the wiki description (and supported by in-game observations of hitting higher than the reduced max hit with a tbow on the second hit of the fight), the 20% damage reduction is tied to the shield, and so it should not be applied to any weapon when unshielded. Currently, the calc only checks to see if the unshielded bonus applies (i.e., it's a heavy ranged or crush weapon or a spell on the unshielded phase), so other weapons are still shown with a damage reduction. 