### PR TITLE
Ignore modifier keys

### DIFF
--- a/src/app/home.tsx
+++ b/src/app/home.tsx
@@ -33,6 +33,9 @@ const Home: NextPage = observer(() => {
     // We only handle events that occur outside <input>, <textarea>, etc
     if (e.target !== document.body) return;
 
+    // Ignore if any modifier keys are held (to not interfere with browser/system shortcuts)
+    if (e.ctrlKey || e.altKey || e.metaKey || e.shiftKey) return;
+
     switch (e.key) {
       case '1':
       case '2':


### PR DESCRIPTION
Pressing Ctrl-1 prevents the user from switching browser tabs. This ignores modifier keys to allow other keyboard shortcuts to work properly.