### PR TITLE
Cap magic damage at 100%

### DIFF
--- a/src/lib/Equipment.ts
+++ b/src/lib/Equipment.ts
@@ -371,6 +371,8 @@ export const calculateEquipmentBonusesFromGear = (player: Player, monster: Monst
     totals.bonuses.ranged_str += 1;
   }
 
+  totals.bonuses.magic_str = Math.min(1000, totals.bonuses.magic_str);
+
   totals.attackSpeed = calculateAttackSpeed(player, monster);
 
   return totals;


### PR DESCRIPTION
I believe this cap only applies to the shadow, although nothing else can ever get close without years of powercrept gear. So I have not added any sort of equipment check. Although I can if that is preferred.

Closes #679