### PR TITLE
Update to add exception when weakness value isn't an int-parseable

### DIFF
--- a/scripts/generateMonsters.py
+++ b/scripts/generateMonsters.py
@@ -226,10 +226,13 @@ def main():
 
         weakness = get_printout_value(po['Elemental weakness']) or None
         if weakness:
-            monster['weakness'] = {
-                'element': weakness.lower(),
-                'severity': int(get_printout_value(po['Elemental weakness percent']) or 0)
-            }
+            try:
+                monster['weakness'] = {
+                    'element': weakness.lower(),
+                    'severity': int(get_printout_value(po['Elemental weakness percent']) or 0)
+                }
+            except:
+                monster['weakness'] = None
         else:
             monster['weakness'] = None
         


### PR DESCRIPTION
The Sea Troll Queen page currently has the elemental weakness listed as confirmation needed. This affects the Elemental weakness percent value stored in the po dictionary. Added a try-except block to catch this and set weakness to none since it's not confirmed