### PR TITLE
Ignore flat armour when using magic

### DIFF
--- a/src/lib/PlayerVsNPCCalc.ts
+++ b/src/lib/PlayerVsNPCCalc.ts
@@ -1774,7 +1774,7 @@ export default class PlayerVsNPCCalc extends BaseCalc {
     }
 
     const flatArmour = this.monster.defensive.flat_armour;
-    if (flatArmour) {
+    if (flatArmour && styleType !== 'magic') {
       dist = dist.transform(
         flatAddTransformer(-flatArmour, 1),
         { transformInaccurate: false },


### PR DESCRIPTION
Closes #692

Inexplicably magic attacks bypass both positive and negative flat armour.
https://discord.com/channels/177206626514632704/1098698914498101368/1401963656421310515
https://discord.com/channels/166812746510368768/534523340275187733/1409936977855250553
https://discord.com/channels/177206626514632704/1098698914498101368/1409942123574329607

This applies to elemental spells, ancient magicks, powered staves, and the voidwaker special attack.