### PR TITLE
Ayak spec fix

### DIFF
--- a/src/lib/scaling/DefenceReduction.ts
+++ b/src/lib/scaling/DefenceReduction.ts
@@ -155,7 +155,7 @@ const applyDefenceReductions = (m: Monster): Monster => {
     m = applyBgsDmg(m, 'ranged');
   }
 
-  if (reductions.ayak > 0) {
+  if (reductions.ayak > 0 && m.defensive.magic > 0) {
     const newMagicDef = Math.max(0, m.defensive.magic - reductions.ayak);
     m = {
       ...m,


### PR DESCRIPTION
This prevents the Eye of Ayak spec from resetting a previously negative magic defense bonus to 0 (fixes #710).