### PR TITLE
Fix Shadow Truncation error

### DIFF
--- a/src/lib/PlayerVsNPCCalc.ts
+++ b/src/lib/PlayerVsNPCCalc.ts
@@ -898,7 +898,7 @@ export default class PlayerVsNPCCalc extends BaseCalc {
         return [75, 150];
       }
     } else if (this.wearing("Tumeken's shadow")) {
-      maxHit = Math.max(1, Math.trunc(magicLevel / 3) + 1);
+      maxHit = Math.max(1, Math.trunc((magicLevel / 3) + 1));
     } else if (this.wearing('Eye of ayak')) {
       maxHit = Math.max(1, Math.trunc(magicLevel / 3) - 6);
     } else if (this.wearing('Warped sceptre')) {


### PR DESCRIPTION
According to the [Wiki](https://oldschool.runescape.wiki/w/Tumeken%27s_shadow#Charged), Tumeken's Shadow's truncation includes the +1. This commit fixes this issue unless the Wiki is wrong