### PR TITLE
Key items based on ID rather than page_name_sub

### DIFF
--- a/scripts/generateEquipmentAliases.py
+++ b/scripts/generateEquipmentAliases.py
@@ -113,8 +113,6 @@ def main():
 
     # Loop over the equipment data from the wiki
     for v in wiki_data:
-        if v['page_name_sub'] in data:
-            continue
 
         print(f"Processing {v['page_name_sub']}")
 
@@ -125,10 +123,15 @@ def main():
             print("Skipping - invalid item ID (not an int)")
             continue
 
-        all_items[v['page_name_sub']] = {
+        if item_id in all_items:
+            # Skip duplicates although the object key also prevents this
+            continue
+
+        all_items[item_id] = {
             'name': v['page_name'],
             'id': item_id,
-            'version': v.get('version_anchor', '')
+            'version': v.get('version_anchor', ''),
+            'page_name_sub': v['page_name_sub'],
         }
 
     all_items = list(all_items.values())


### PR DESCRIPTION
The equipment aliases was using page_name_sub as a key to prevent duplicates. For equipment aliases this is not desired. For example, the black mask (i) has a switch infobox with all three imbue sources and a dropdown within each for all 11 charge states. Keying off page_name_sub would only get 11 items rather than 33 items. Switching to key off the item_id allows for better item variation mapping.