### PR TITLE
stop zeroing out boosts when comparing loadouts

### DIFF
--- a/src/lib/Comparator.ts
+++ b/src/lib/Comparator.ts
@@ -90,7 +90,7 @@ export default class Comparator {
       monster: this.baseMonster,
     });
 
-    const skillInput = (x: number, stat: keyof PlayerSkills): InputSet => playerInput(x, { skills: { [stat]: x }, boosts: { [stat]: 0 } });
+    const skillInput = (x: number, stat: keyof PlayerSkills): InputSet => playerInput(x, { skills: { [stat]: x } });
 
     switch (this.xAxis) {
       case CompareXAxis.MONSTER_DEF:

--- a/src/tests/Comparator.test.ts
+++ b/src/tests/Comparator.test.ts
@@ -16,7 +16,7 @@ test('Loadout comparison graph reflects strength boosts', () => {
   );
 
   const [entries] = comparator.getEntries();
-  
+
   // Find the entry for strength level 70
   const atLevel70 = entries.find((e) => e.name === 70);
   expect(atLevel70).toBeDefined();

--- a/src/tests/Comparator.test.ts
+++ b/src/tests/Comparator.test.ts
@@ -1,0 +1,29 @@
+import { expect, test } from '@jest/globals';
+import { getTestMonster, getTestPlayer } from '@/tests/utils/TestUtils';
+import Comparator, { CompareXAxis, CompareYAxis } from '@/lib/Comparator';
+
+test('Loadout comparison graph reflects strength boosts', () => {
+  const monster = getTestMonster('Abyssal demon', 'Standard');
+
+  const withoutBoost = getTestPlayer(monster, { name: 'no boost', skills: { str: 70 } });
+  const withBoost = getTestPlayer(monster, { name: 'super str', skills: { str: 70 }, boosts: { str: 19 } });
+
+  const comparator = new Comparator(
+    [withoutBoost, withBoost],
+    monster,
+    CompareXAxis.PLAYER_STRENGTH_LEVEL,
+    CompareYAxis.PLAYER_DPS,
+  );
+
+  const [entries] = comparator.getEntries();
+  
+  // Find the entry for strength level 70
+  const atLevel70 = entries.find((e) => e.name === 70);
+  expect(atLevel70).toBeDefined();
+
+  const dpsWithout = parseFloat(atLevel70!['no boost'] as string);
+  const dpsWith = parseFloat(atLevel70!['super str'] as string);
+
+  // The boosted loadout should have higher DPS at the same base strength level
+  expect(dpsWith).toBeGreaterThan(dpsWithout);
+});


### PR DESCRIPTION
I was looking at the Loadout Comparison Graph with Strength Level as the X axis and noticed that my super strength potions weren't being factored into the graph, despite being correctly handled in the primary Results window.

It does look like the zeroing out of the boosts was intentional, so I'm suspicious of my change.  I have tested it to verify that it works in the place where I expect it to, but maybe this change is breaking something else?