### PR TITLE
Add strength bonuses to loadout comparison plots

### DIFF
--- a/src/app/components/results/LoadoutComparison.tsx
+++ b/src/app/components/results/LoadoutComparison.tsx
@@ -37,6 +37,9 @@ const XAxisOptions = [
   { label: 'Player ranged level', axisLabel: 'Level', value: CompareXAxis.PLAYER_RANGED_LEVEL },
   { label: 'Player magic level', axisLabel: 'Level', value: CompareXAxis.PLAYER_MAGIC_LEVEL },
   { label: 'Player stat decay', axisLabel: 'Minutes after boost', value: CompareXAxis.STAT_DECAY_RESTORE },
+  { label: 'Player melee strength bonus', axisLabel: 'Bonus', value: CompareXAxis.PLAYER_MELEE_STRENGTH_BONUS },
+  { label: 'Player ranged strength bonus', axisLabel: 'Bonus', value: CompareXAxis.PLAYER_RANGED_STRENGTH_BONUS },
+  { label: 'Player magic strength bonus', axisLabel: 'Bonus', value: CompareXAxis.PLAYER_MAGIC_STRENGTH_BONUS },
 ];
 
 const CustomTooltip: React.FC<TooltipProps<ValueType, NameType>> = ({ active, payload, label }) => {

--- a/src/lib/Comparator.ts
+++ b/src/lib/Comparator.ts
@@ -22,6 +22,9 @@ export enum CompareXAxis {
   PLAYER_MAGIC_LEVEL,
   STAT_DECAY_RESTORE,
   PLAYER_DEFENCE_LEVEL,
+  PLAYER_MELEE_STRENGTH_BONUS,
+  PLAYER_RANGED_STRENGTH_BONUS,
+  PLAYER_MAGIC_STRENGTH_BONUS,
 }
 
 export enum CompareYAxis {
@@ -179,6 +182,27 @@ export default class Comparator {
             loadouts: restoredLoadouts,
             monster: this.baseMonster,
           };
+        }
+        return;
+      }
+
+      case CompareXAxis.PLAYER_MELEE_STRENGTH_BONUS: {
+        for (let newStrBonus = 0; newStrBonus <= 225; newStrBonus++) {
+          yield playerInput(newStrBonus, { bonuses: { str: newStrBonus } });
+        }
+        return;
+      }
+
+      case CompareXAxis.PLAYER_RANGED_STRENGTH_BONUS: {
+        for (let newStrBonus = 0; newStrBonus <= 200; newStrBonus++) {
+          yield playerInput(newStrBonus, { bonuses: { ranged_str: newStrBonus } });
+        }
+        return;
+      }
+
+      case CompareXAxis.PLAYER_MAGIC_STRENGTH_BONUS: {
+        for (let newStrBonus = 0; newStrBonus <= 100; newStrBonus += 0.5) {
+          yield playerInput(newStrBonus, { bonuses: { magic_str: newStrBonus * 10 } });
         }
         return;
       }


### PR DESCRIPTION
This adds the ability to see how melee, ranged, or magic strength bonus affects the player's max hit/DPS, which is a feature that's been requested a few times. I chose to display the plots from 0 strength bonus up to values that are slightly higher than (or equal to, for magic) the maximum currently achievable strength bonus for that style.