### PR TITLE
Accuracy roll *is* supported

### DIFF
--- a/src/lib/BaseCalc.ts
+++ b/src/lib/BaseCalc.ts
@@ -816,9 +816,6 @@ export default class BaseCalc {
     if (leaguesEffects.talent_prayer_pen_all) {
       this.addIssue(UserIssueType.LEAGUES_SIX_TALENT_UNSUPPORTED, 'Prayer Penetration (coming soon)');
     }
-    if (leaguesEffects.talent_all_style_accuracy) {
-      this.addIssue(UserIssueType.LEAGUES_SIX_TALENT_UNSUPPORTED, 'Max Accuracy Roll Chance (coming soon)');
-    }
     if (leaguesEffects.talent_max_hit_style_swap) {
       this.addIssue(UserIssueType.LEAGUES_SIX_TALENT_UNSUPPORTED, 'Style Swap Damage Bonus');
     }


### PR DESCRIPTION
As far as I can see `talent_all_style_accuracy` is properly handled here: https://github.com/weirdgloop/osrs-dps-calc/blob/4a468a6f5aeeb8649ee67a0fe5a5dbfce5c74dc8/src/lib/PlayerVsNPCCalc.ts#L1182-L1185