### PR TITLE
Add Support for Demonic Pact: Maximum Accuracy roll chance scaling with distance

### DIFF
--- a/src/lib/BaseCalc.ts
+++ b/src/lib/BaseCalc.ts
@@ -194,6 +194,27 @@ export default class BaseCalc {
   }
 
   /**
+   * Helper function that calculates the hit chance for mechanics that force a maximum accuracy roll.
+   * @param atk Attack roll of the player
+   * @param def Defence roll of the NPC
+   * @returns Hit chance of the attack
+   */
+  public static getMaxAccuracyHitChance(atk: number, def: number): number {
+    const stdRoll = (attack: number, defence: number) => ((attack > defence)
+      ? 1
+      : attack / (defence + 1));
+
+    if (atk < 0) atk = Math.min(0, atk + 2);
+    if (def < 0) def = Math.min(0, def + 2);
+
+    if (atk >= 0 && def >= 0) return stdRoll(atk, def);
+    if (atk >= 0 && def < 0) return 1;
+    if (atk < 0 && def >= 0) return 0;
+    if (atk < 0 && def < 0) return stdRoll(-def, -atk);
+    return 0;
+  }
+
+  /**
    * Simple utility function for checking if an item name is equipped. If an array of string is passed instead, this
    * function will return a boolean indicating whether ANY of the provided items are equipped.
    * @param item - item name

--- a/src/lib/PlayerVsNPCCalc.ts
+++ b/src/lib/PlayerVsNPCCalc.ts
@@ -1372,7 +1372,7 @@ export default class PlayerVsNPCCalc extends BaseCalc {
     if (this.player.leagues.six.effects.talent_max_accuracy_roll_from_range) {
       const distance = this.player.leagues.six.distanceToEnemy;
       // Proc chance capped to 20 tiles (guaranteed success) - technically there is a 10 tile range cap for all weapons which is not respected here.
-      const procChance = Math.min(1, (5 * (distance + 1)) / 100);
+      const procChance = Math.min(1, 0.05 * distance);
       const maxAccuracyHitChance = BaseCalc.getMaxAccuracyHitChance(atk, def);
       hitChance = hitChance * (1 - procChance) + maxAccuracyHitChance * procChance;
     }

--- a/src/lib/PlayerVsNPCCalc.ts
+++ b/src/lib/PlayerVsNPCCalc.ts
@@ -1369,6 +1369,14 @@ export default class PlayerVsNPCCalc extends BaseCalc {
       hitChance = this.track(DetailKey.PLAYER_ACCURACY_CONFLICTION_GAUNTLETS, BaseCalc.getConflictionGauntletsAccuracyRoll(atk, def));
     }
 
+    if (this.player.leagues.six.effects.talent_max_accuracy_roll_from_range) {
+      const distance = this.player.leagues.six.distanceToEnemy;
+      // Proc chance capped to 20 tiles (guaranteed success) - technically there is a 10 tile range cap for all weapons which is not respected here.
+      const procChance = Math.min(1, (5 * (distance + 1)) / 100);
+      const maxAccuracyHitChance = BaseCalc.getMaxAccuracyHitChance(atk, def);
+      hitChance = hitChance * (1 - procChance) + maxAccuracyHitChance * procChance;
+    }
+
     return this.track(DetailKey.PLAYER_ACCURACY_FINAL, hitChance);
   }
 


### PR DESCRIPTION
Adds support for the demonic pacts league "node9"

<img width="384" height="135" alt="image" src="https://github.com/user-attachments/assets/71e1bd6b-748f-4936-b641-2d09535505a8" />

Added a new helper that can be used for future calculations that force a maximum accuracy roll as well.

Before:
<img width="610" height="334" alt="image" src="https://github.com/user-attachments/assets/55fe1933-8656-46d9-9e0f-d055a0aa6ac5" />


After:
<img width="609" height="338" alt="image" src="https://github.com/user-attachments/assets/4a7f8a34-81ae-48ac-ad2c-032331865a2f" />
