### PR TITLE
Make "distance to enemy" consistent with weapon range

### DIFF
--- a/src/app/components/player/DemonicPactsLeague.tsx
+++ b/src/app/components/player/DemonicPactsLeague.tsx
@@ -188,7 +188,7 @@ const DemonicPactsLeague: React.FC = observer(() => {
             aria-labelledby="distanceToEnemyLabel"
             className="form-control w-12 text-centerl"
             id="distanceToEnemy"
-            min={0}
+            min={1}
             max={99}
             title="Distance to enemy"
             value={store.player.leagues.six.distanceToEnemy}
@@ -196,7 +196,18 @@ const DemonicPactsLeague: React.FC = observer(() => {
               store.updatePlayer({ leagues: { six: { distanceToEnemy: v } } });
             }}
           />
-          <span id="distanceToEnemyLabel">Distance to Enemy</span>
+
+          <span id="distanceToEnemyLabel" className="ml-1 text-sm select-none">
+            Distance to enemy (tiles)
+            {' '}
+            <span
+              className="align-super underline decoration-dotted cursor-help text-xs text-gray-300"
+              data-tooltip-id="tooltip"
+              data-tooltip-content="This affects some pacts. When you stand on the tile adjacent to an enemy your distance is 1."
+            >
+              ?
+            </span>
+          </span>
         </div>
 
         <ShowIfLeagueEffectEnabled leaguesEffect="talent_free_random_weapon_attack_chance">

--- a/src/app/components/player/DemonicPactsLeague.tsx
+++ b/src/app/components/player/DemonicPactsLeague.tsx
@@ -189,7 +189,7 @@ const DemonicPactsLeague: React.FC = observer(() => {
             className="form-control w-12 text-centerl"
             id="distanceToEnemy"
             min={1}
-            max={99}
+            max={10}
             title="Distance to enemy"
             value={store.player.leagues.six.distanceToEnemy}
             onChange={(v) => {

--- a/src/lib/PlayerVsNPCCalc.ts
+++ b/src/lib/PlayerVsNPCCalc.ts
@@ -457,7 +457,7 @@ export default class PlayerVsNPCCalc extends BaseCalc {
     }
 
     if (this.player.leagues.six.effects.talent_percentage_melee_maxhit_distance) {
-      const tilesBetween = this.player.leagues.six.distanceToEnemy - 1;
+      const tilesBetween = this.player.leagues.six.distanceToEnemy;
       const maxhitFactor = 100 + 4 * (Math.floor(tilesBetween / 3) + 1);
       maxHit = this.trackFactor(DetailKey.LEAGUES_MAX_HIT_DISTANCE_MELEE, maxHit, [maxhitFactor, 100]);
     }

--- a/src/lib/PlayerVsNPCCalc.ts
+++ b/src/lib/PlayerVsNPCCalc.ts
@@ -452,14 +452,13 @@ export default class PlayerVsNPCCalc extends BaseCalc {
     }
 
     if (this.player.leagues.six.effects.talent_distance_melee_minhit) {
-      const distance = this.player.leagues.six.distanceToEnemy;
-      const minhitBonus = 3 * (distance + 1);
+      const minhitBonus = 3 * this.player.leagues.six.distanceToEnemy;
       minHit = this.trackAdd(DetailKey.LEAGUES_MIN_HIT_DISTANCE_MELEE, minHit, minhitBonus);
     }
 
     if (this.player.leagues.six.effects.talent_percentage_melee_maxhit_distance) {
-      const distance = this.player.leagues.six.distanceToEnemy;
-      const maxhitFactor = 100 + 4 * (Math.floor(distance / 3) + 1);
+      const tilesBetween = this.player.leagues.six.distanceToEnemy - 1;
+      const maxhitFactor = 100 + 4 * (Math.floor(tilesBetween / 3) + 1);
       maxHit = this.trackFactor(DetailKey.LEAGUES_MAX_HIT_DISTANCE_MELEE, maxHit, [maxhitFactor, 100]);
     }
 

--- a/src/state.tsx
+++ b/src/state.tsx
@@ -143,7 +143,7 @@ export const generateEmptyPlayer = (name?: string): Player => ({
     six: {
       selectedNodeIds: new Set<string>(['node1']),
       effects: {},
-      distanceToEnemy: 0,
+      distanceToEnemy: 1,
       enemyPrayers: {
         melee: false,
         ranged: false,
@@ -535,6 +535,18 @@ class GlobalState implements State {
             burn: null,
           };
         }
+
+      case 8:
+        // Definition of distanceToEnemy changed from 'tiles between' to
+        // 'distance' to match weapon range.
+        data.loadouts.forEach((l) => {
+          /* eslint-disable @typescript-eslint/no-explicit-any */
+          const six = (l as any)?.leagues?.six;
+          if (six) {
+            six.distanceToEnemy += 1;
+          }
+          /* eslint-enable @typescript-eslint/no-explicit-any */
+        });
 
       default:
     }

--- a/src/state.tsx
+++ b/src/state.tsx
@@ -543,7 +543,7 @@ class GlobalState implements State {
           /* eslint-disable @typescript-eslint/no-explicit-any */
           const six = (l as any)?.leagues?.six;
           if (six) {
-            six.distanceToEnemy += 1;
+            six.distanceToEnemy = Math.min(10, six.distanceToEnemy + 1);
           }
           /* eslint-enable @typescript-eslint/no-explicit-any */
         });

--- a/src/types/State.ts
+++ b/src/types/State.ts
@@ -90,7 +90,7 @@ export interface Calculator {
  * or any of its subproperties, are updated in a non-backwards-compatible manner,
  * or also in any manner that could affect the migrations required on load.
  */
-export const IMPORT_VERSION = 8 as const;
+export const IMPORT_VERSION = 9 as const;
 
 /**
  * This is the state that can be exported and imported (through shortlinks).


### PR DESCRIPTION
The demonic pacts "distance to enemy" field was very confusing, because it counted empty tiles between you and the enemy, rather than the usual distance measurement used in OSRS for weapon range (where default unboosted melee weapon range is 1). I expect people will want to simply put their weapon range into this field, so I changed it to match weapon range. I also added a clarification tooltip:

<img width="521" height="72" alt="image" src="https://github.com/user-attachments/assets/6259b890-a1aa-4e1a-9ae2-106733928509" />

---

Because this is a breaking change I updated `IMPORT_VERSION` and added a migration step.

Note: if this is merged https://github.com/weirdgloop/osrs-dps-calc/pull/787 needs to be updated to use the new definition.