### PR TITLE
Implement overheal consumption effects (melee & fire spells)

### DIFF
--- a/src/lib/BaseCalc.ts
+++ b/src/lib/BaseCalc.ts
@@ -847,8 +847,5 @@ export default class BaseCalc {
     if (leaguesEffects.talent_thorns_damage || leaguesEffects.talent_shield_reflect) {
       this.addIssue(UserIssueType.LEAGUES_SIX_TALENT_UNSUPPORTED, 'Thorns');
     }
-    if (leaguesEffects.talent_overheal_consumption_boost || leaguesEffects.talent_fire_hp_consume_for_damage) {
-      this.addIssue(UserIssueType.LEAGUES_SIX_TALENT_UNSUPPORTED, 'Overheal Consumption Effects');
-    }
   }
 }

--- a/src/lib/CalcDetails.ts
+++ b/src/lib/CalcDetails.ts
@@ -93,6 +93,7 @@ export enum DetailKey {
   DIST_BASE = 'Dist base',
   DIST_LEAGUES_AIR_SPELL_PRAYER_COUNT = 'Dist leagues talent_air_spell_damage_active_prayers',
   DIST_LEAGUES_WATER_SPELL_DAMAGE_HIGH_HP = 'Dist leagues talent_water_spell_damage_high_hp',
+  DIST_LEAGUES_FIRE_SPELL_HP_CONSUME = 'Dist leagues talent_fire_hp_consume_for_damage',
   DIST_LEAGUES_ECHO = 'Dist leagues echo',
   DIST_LEAGUES_ECHO_CYCLICAL = 'Dist leagues echo cyclical',
   DIST_FINAL = 'Dist final',
@@ -127,6 +128,7 @@ export enum DetailKey {
   LEAGUES_ECHO_CHANCE_ACCURACY = 'Player echo chance accuracy',
   LEAGUES_MIN_HIT_DISTANCE_MELEE = 'Player distance melee min hit',
   LEAGUES_MAX_HIT_DISTANCE_MELEE = 'Player distance melee max hit',
+  LEAGUES_MIN_HIT_OVERHEAL_CONSUMPTION = 'Player overheal consumption min hit',
   LEAGUES_BLINDBAG_DAMAGE_BONUS = 'Player blindbag uniques max hit',
   LEAGUES_BLINDBAG_CHANCE_UNIQUE = 'Player blindbag uniques chance',
 }

--- a/src/lib/PlayerVsNPCCalc.ts
+++ b/src/lib/PlayerVsNPCCalc.ts
@@ -459,6 +459,10 @@ export default class PlayerVsNPCCalc extends BaseCalc {
       minHit = this.trackAdd(DetailKey.LEAGUES_MIN_HIT_DISTANCE_MELEE, minHit, minhitBonus);
     }
 
+    if (this.player.leagues.six.effects.talent_overheal_consumption_boost && this.player.boosts.hp >= 5) {
+      minHit = this.trackAdd(DetailKey.LEAGUES_MIN_HIT_OVERHEAL_CONSUMPTION, minHit, 5);
+    }
+
     if (this.player.leagues.six.effects.talent_percentage_melee_maxhit_distance) {
       const tilesBetween = this.player.leagues.six.distanceToEnemy;
       const maxhitFactor = 100 + 4 * (Math.floor(tilesBetween / 3) + 1);
@@ -1538,6 +1542,17 @@ export default class PlayerVsNPCCalc extends BaseCalc {
       const bonusDamagePerPrayer = leagues.effects.talent_air_spell_damage_active_prayers;
       dist = dist.transform(multiplyTransformer(100 + (prayersActive * bonusDamagePerPrayer), 100));
       this.trackDist(DetailKey.DIST_LEAGUES_AIR_SPELL_PRAYER_COUNT, dist);
+    }
+
+    if (leagues.effects.talent_fire_hp_consume_for_damage && spellement === 'fire') {
+      const currentHp = this.player.skills.hp + this.player.boosts.hp;
+
+      // 6% of max hp.
+      const maxConsume = Math.trunc(this.player.skills.hp * 0.06);
+      // Effect cannot kill player.
+      const actualConsume = Math.min(maxConsume, currentHp - 1);
+      dist = dist.transform(flatAddTransformer(actualConsume * 2));
+      this.trackDist(DetailKey.DIST_LEAGUES_FIRE_SPELL_HP_CONSUME, dist);
     }
 
     if (this.player.leagues.six.effects.talent_water_spell_damage_high_hp && spellement === 'water') {

--- a/src/lib/PlayerVsNPCCalc.ts
+++ b/src/lib/PlayerVsNPCCalc.ts
@@ -1547,8 +1547,8 @@ export default class PlayerVsNPCCalc extends BaseCalc {
     if (leagues.effects.talent_fire_hp_consume_for_damage && spellement === 'fire') {
       const currentHp = this.player.skills.hp + this.player.boosts.hp;
 
-      // 6% of max hp.
-      const maxConsume = Math.trunc(this.player.skills.hp * 0.06);
+      // 6% of current hp.
+      const maxConsume = Math.trunc(currentHp * 0.06);
       // Effect cannot kill player.
       const actualConsume = Math.min(maxConsume, currentHp - 1);
       dist = dist.transform(flatAddTransformer(actualConsume * 2));


### PR DESCRIPTION
(fire isn't specifically overheal consumption but decided to fix both in one PR)

- Adds min hit of 5 to melee if overhealed by atleast 5hp (from wording I am assuming it wont consume less than 5)
- Adds flat damage equal to double of 6% of max hp or max damage without killing (whichever is smaller)

Not intending to accumulate hp consumed here, just assuming the player is somehow healing that hp before next attack. Anything else would be confusing. Also not sure how this plays into multihit attacks, I would assume damage is dealt once per attack but minhit is increased for all hits.