### PR TITLE
Fix 'crossbows always max hit' on bolt procs

### DIFF
--- a/src/lib/PlayerVsNPCCalc.ts
+++ b/src/lib/PlayerVsNPCCalc.ts
@@ -64,7 +64,7 @@ import BaseCalc, { CalcOpts, InternalOpts } from '@/lib/BaseCalc';
 import { scaleMonster, scaleMonsterHpOnly } from '@/lib/MonsterScaling';
 import { CombatStyleType, getRangedDamageType } from '@/types/PlayerCombatStyle';
 import { range, some, sum } from 'd3-array';
-import { FeatureStatus, getCombatStylesForCategory } from '@/utils';
+import { FeatureStatus, getCombatStylesForCategory, isDefined } from '@/utils';
 import UserIssueType from '@/enums/UserIssueType';
 import {
   BoltContext,
@@ -1788,7 +1788,7 @@ export default class PlayerVsNPCCalc extends BaseCalc {
     // bolt effects
     const boltContext: BoltContext = {
       maxHit: max,
-      alwaysMaxHit: !!this.player.leagues.six.effects.talent_crossbow_max_hit,
+      alwaysMaxHit: isDefined(this.player.leagues.six.effects.talent_crossbow_max_hit),
       rangedLvl: this.player.skills.ranged + this.player.boosts.ranged,
       zcb: this.wearing('Zaryte crossbow'),
       spec: this.opts.usingSpecialAttack,

--- a/src/lib/PlayerVsNPCCalc.ts
+++ b/src/lib/PlayerVsNPCCalc.ts
@@ -1788,6 +1788,7 @@ export default class PlayerVsNPCCalc extends BaseCalc {
     // bolt effects
     const boltContext: BoltContext = {
       maxHit: max,
+      alwaysMaxHit: !!this.player.leagues.six.effects.talent_crossbow_max_hit,
       rangedLvl: this.player.skills.ranged + this.player.boosts.ranged,
       zcb: this.wearing('Zaryte crossbow'),
       spec: this.opts.usingSpecialAttack,

--- a/src/lib/dists/bolts.ts
+++ b/src/lib/dists/bolts.ts
@@ -9,6 +9,7 @@ import { INFINITE_HEALTH_MONSTERS } from '@/lib/constants';
 export interface BoltContext {
   rangedLvl: number;
   maxHit: number;
+  alwaysMaxHit: boolean;
   zcb: boolean;
   spec: boolean;
   kandarinDiary: boolean;
@@ -53,7 +54,9 @@ export const diamondBolts: BoltTransformer = (ctx) => {
   const chance = 0.1 * kandarinFactor(ctx);
   const effectMax = Math.trunc(maxHit * (zcb ? 126 : 115) / 100);
 
-  const effectDist = HitDistribution.linear(1.0, 0, effectMax);
+  const effectDist = ctx.alwaysMaxHit
+    ? HitDistribution.single(1.0, [new Hitsplat(effectMax)])
+    : HitDistribution.linear(1.0, 0, effectMax);
   return (h) => {
     if (h.accurate && zcb && spec) {
       return effectDist;
@@ -92,7 +95,9 @@ export const onyxBolts: BoltTransformer = (ctx) => {
   const chance = 0.11 * kandarinFactor(ctx);
   const effectMax = Math.trunc(maxHit * (zcb ? 132 : 120) / 100);
 
-  const effectDist = HitDistribution.linear(1.0, 0, effectMax);
+  const effectDist = ctx.alwaysMaxHit
+    ? HitDistribution.single(1.0, [new Hitsplat(effectMax)])
+    : HitDistribution.linear(1.0, 0, effectMax);
   return (h) => {
     if (!h.accurate) {
       return new HitDistribution([new WeightedHit(1.0, [h])]);


### PR DESCRIPTION
I fixed the problem that bolt procs didn't respect the demonic pact that makes crossbows always max hit.

This is an example setup that shows you would lose damage from using onyx bolts (e): https://dps.osrs.wiki?id=PartsReliefRatpits.