### PR TITLE
Add 6 missing Demonic Pacts League echo equipment items

### DIFF
--- a/cdn/json/equipment.json
+++ b/cdn/json/equipment.json
@@ -163118,5 +163118,191 @@
       "ranged": 0
     },
     "isTwoHanded": false
+  },
+  {
+    "name": "Infernal tecpatl",
+    "id": 1000102,
+    "weight": 3.628,
+    "version": "",
+    "slot": "weapon",
+    "image": "Infernal tecpatl.png",
+    "speed": 4,
+    "category": "Blunt",
+    "bonuses": {
+      "str": 70,
+      "ranged_str": 0,
+      "magic_str": 0,
+      "prayer": -1
+    },
+    "offensive": {
+      "stab": 72,
+      "slash": 72,
+      "crush": 72,
+      "magic": 0,
+      "ranged": 0
+    },
+    "defensive": {
+      "stab": 0,
+      "slash": 0,
+      "crush": 0,
+      "magic": 0,
+      "ranged": 0
+    },
+    "isTwoHanded": true
+  },
+  {
+    "name": "Fang of the hound",
+    "id": 1000103,
+    "weight": 0.666,
+    "version": "",
+    "slot": "weapon",
+    "image": "Fang of the hound.png",
+    "speed": 3,
+    "category": "Stab Sword",
+    "bonuses": {
+      "str": 20,
+      "ranged_str": 0,
+      "magic_str": 0,
+      "prayer": 0
+    },
+    "offensive": {
+      "stab": 60,
+      "slash": 60,
+      "crush": 10,
+      "magic": 3,
+      "ranged": 0
+    },
+    "defensive": {
+      "stab": 0,
+      "slash": 0,
+      "crush": 0,
+      "magic": 0,
+      "ranged": 0
+    },
+    "isTwoHanded": false
+  },
+  {
+    "name": "Devil's element",
+    "id": 1000104,
+    "weight": 0.2,
+    "version": "",
+    "slot": "shield",
+    "image": "Devil's element.png",
+    "speed": 0,
+    "category": "",
+    "bonuses": {
+      "str": 0,
+      "ranged_str": 0,
+      "magic_str": 6,
+      "prayer": 3
+    },
+    "offensive": {
+      "stab": 0,
+      "slash": 0,
+      "crush": 0,
+      "magic": 20,
+      "ranged": 0
+    },
+    "defensive": {
+      "stab": 0,
+      "slash": 0,
+      "crush": 0,
+      "magic": 0,
+      "ranged": 0
+    },
+    "isTwoHanded": false
+  },
+  {
+    "name": "Shadowflame quadrant",
+    "id": 1000105,
+    "weight": 1.5,
+    "version": "",
+    "slot": "weapon",
+    "image": "Shadowflame quadrant.png",
+    "speed": 5,
+    "category": "Staff",
+    "bonuses": {
+      "str": 50,
+      "ranged_str": 0,
+      "magic_str": 15,
+      "prayer": 0
+    },
+    "offensive": {
+      "stab": 0,
+      "slash": 0,
+      "crush": 60,
+      "magic": 25,
+      "ranged": 0
+    },
+    "defensive": {
+      "stab": 0,
+      "slash": 0,
+      "crush": 5,
+      "magic": 17,
+      "ranged": 0
+    },
+    "isTwoHanded": false
+  },
+  {
+    "name": "King's barrage",
+    "id": 1000106,
+    "weight": 3.0,
+    "version": "",
+    "slot": "weapon",
+    "image": "King's barrage.png",
+    "speed": 5,
+    "category": "Crossbow",
+    "bonuses": {
+      "str": 0,
+      "ranged_str": 14,
+      "magic_str": 0,
+      "prayer": 0
+    },
+    "offensive": {
+      "stab": 0,
+      "slash": 0,
+      "crush": 0,
+      "magic": 0,
+      "ranged": 130
+    },
+    "defensive": {
+      "stab": 20,
+      "slash": 20,
+      "crush": 20,
+      "magic": 25,
+      "ranged": 60
+    },
+    "isTwoHanded": false
+  },
+  {
+    "name": "Lithic sceptre",
+    "id": 1000107,
+    "weight": 2.0,
+    "version": "",
+    "slot": "weapon",
+    "image": "Lithic sceptre.png",
+    "speed": 4,
+    "category": "Powered Staff",
+    "bonuses": {
+      "str": 0,
+      "ranged_str": 0,
+      "magic_str": 0,
+      "prayer": 0
+    },
+    "offensive": {
+      "stab": 0,
+      "slash": 0,
+      "crush": 0,
+      "magic": 25,
+      "ranged": 0
+    },
+    "defensive": {
+      "stab": 10,
+      "slash": 10,
+      "crush": 10,
+      "magic": 20,
+      "ranged": 0
+    },
+    "isTwoHanded": false
   }
 ]

--- a/src/lib/BaseCalc.ts
+++ b/src/lib/BaseCalc.ts
@@ -381,6 +381,7 @@ export default class BaseCalc {
       'Sulphur blades',
       'Glacial temotli',
       'Earthbound tecpatl',
+      'Infernal tecpatl',
     ]);
   }
 

--- a/src/lib/Equipment.ts
+++ b/src/lib/Equipment.ts
@@ -159,6 +159,7 @@ const ammoForRangedWeapons: { [weapon: number]: number[] } = {
   28869: [28872, 28878], // Hunters' sunlight crossbow
   29000: [28991], // Eclipse atlatl
   1000101: commonAmmoCategories().bow_t60, // Nature's recurve
+  1000106: commonAmmoCategories().cb_t64, // King's barrage
 };
 
 export enum AmmoApplicability {

--- a/src/lib/PlayerVsNPCCalc.ts
+++ b/src/lib/PlayerVsNPCCalc.ts
@@ -248,6 +248,9 @@ export default class PlayerVsNPCCalc extends BaseCalc {
     if (this.wearing(['Bone claws', 'Burning claws']) && mattrs.includes(MonsterAttribute.DEMON)) {
       attackRoll = this.trackAddFactor(DetailKey.PLAYER_ACCURACY_DEMONBANE, attackRoll, this.demonbaneFactor(5));
     }
+    if (this.wearing('Infernal tecpatl') && mattrs.includes(MonsterAttribute.DEMON)) {
+      attackRoll = this.trackAddFactor(DetailKey.PLAYER_ACCURACY_DEMONBANE, attackRoll, this.demonbaneFactor(10));
+    }
     if (mattrs.includes(MonsterAttribute.DRAGON)) {
       if (this.wearing('Dragon hunter lance')) {
         attackRoll = this.trackFactor(DetailKey.PLAYER_ACCURACY_DRAGONHUNTER, attackRoll, [6, 5]);
@@ -388,6 +391,9 @@ export default class PlayerVsNPCCalc extends BaseCalc {
     }
     if (this.wearing(['Bone claws', 'Burning claws']) && mattrs.includes(MonsterAttribute.DEMON)) {
       maxHit = this.trackAddFactor(DetailKey.MAX_HIT_DEMONBANE, maxHit, this.demonbaneFactor(5));
+    }
+    if (this.wearing('Infernal tecpatl') && mattrs.includes(MonsterAttribute.DEMON)) {
+      maxHit = this.trackAddFactor(DetailKey.MAX_HIT_DEMONBANE, maxHit, this.demonbaneFactor(10));
     }
     if (this.isWearingTzhaarWeapon() && this.isWearingObsidian()) {
       const obsidianBonus = this.trackFactor(DetailKey.MAX_HIT_OBSIDIAN, baseMax, [1, 10]);
@@ -925,9 +931,19 @@ export default class PlayerVsNPCCalc extends BaseCalc {
     }
 
     const spellement = this.getSpellement();
-    if (this.monster.weakness && spellement) {
-      if (spellement === this.monster.weakness.element) {
-        const severity = this.monster.weakness.severity;
+    if (spellement) {
+      let severity = 0;
+      if (this.monster.weakness) {
+        // Shadowflame quadrant: always use the target's weakness regardless of spell element
+        if (this.wearing('Shadowflame quadrant') || spellement === this.monster.weakness.element) {
+          severity = this.monster.weakness.severity;
+        }
+      }
+      // Devil's element adds 30% elemental weakness to all elements
+      if (this.wearing("Devil's element")) {
+        severity += 30;
+      }
+      if (severity > 0) {
         const bonus = this.trackFactor(DetailKey.PLAYER_ACCURACY_SPELLEMENT_BONUS, baseRoll, [severity, 100]);
         attackRoll = this.trackAdd(DetailKey.PLAYER_ACCURACY_SPELLEMENT, attackRoll, bonus);
       }
@@ -989,6 +1005,8 @@ export default class PlayerVsNPCCalc extends BaseCalc {
       // although the +10 is technically a ratbane bonus, the weapon can't be used against non-rats
       // and shows this max hit against the combat dummy as well
       maxHit = Math.max(1, Math.trunc(magicLevel / 3) - 5) + 10;
+    } else if (this.wearing('Lithic sceptre')) {
+      maxHit = Math.max(10, Math.trunc(magicLevel / 3) - 10);
     } else if (this.wearing('Eldritch nightmare staff') && this.opts.usingSpecialAttack) {
       maxHit = Math.max(1, Math.min(44, Math.trunc((99 + 44 * magicLevel) / 99)));
     } else if (this.wearing('Volatile nightmare staff') && this.opts.usingSpecialAttack) {
@@ -1081,9 +1099,19 @@ export default class PlayerVsNPCCalc extends BaseCalc {
     }
 
     const spellement = this.getSpellement();
-    if (this.monster.weakness && spellement) {
-      if (spellement === this.monster.weakness.element) {
-        const severity = this.monster.weakness.severity;
+    if (spellement) {
+      let severity = 0;
+      if (this.monster.weakness) {
+        // Shadowflame quadrant: always use the target's weakness regardless of spell element
+        if (this.wearing('Shadowflame quadrant') || spellement === this.monster.weakness.element) {
+          severity = this.monster.weakness.severity;
+        }
+      }
+      // Devil's element adds 30% elemental weakness to all elements
+      if (this.wearing("Devil's element")) {
+        severity += 30;
+      }
+      if (severity > 0) {
         const bonus = this.trackFactor(DetailKey.MAX_HIT_SPELLEMENT_BONUS, baseMax, [severity, 100]);
         maxHit = this.trackAdd(DetailKey.MAX_HIT_SPELLEMENT, maxHit, bonus);
       }
@@ -1777,7 +1805,8 @@ export default class PlayerVsNPCCalc extends BaseCalc {
       kandarinDiary: this.player.buffs.kandarinDiary,
       monster: this.monster,
     };
-    if (this.player.style.type === 'ranged' && this.player.equipment.weapon?.name.includes('rossbow')) {
+    const isCrossbow = this.player.equipment.weapon?.name.includes('rossbow') || this.player.equipment.weapon?.category === 'Crossbow';
+    if (this.player.style.type === 'ranged' && isCrossbow) {
       if (this.wearing(['Opal bolts (e)', 'Opal dragon bolts (e)'])) {
         dist = dist.transform(opalBolts(boltContext));
       } else if (this.wearing(['Pearl bolts (e)', 'Pearl dragon bolts (e)'])) {
@@ -1789,6 +1818,34 @@ export default class PlayerVsNPCCalc extends BaseCalc {
       } else if (this.wearing(['Onyx bolts (e)', 'Onyx dragon bolts (e)']) && !mattrs.includes(MonsterAttribute.UNDEAD)) {
         dist = dist.transform(onyxBolts(boltContext));
       }
+    }
+
+    // Fang of the hound: 5% chance per hit to cast Flames of Cerberus
+    // Fire elemental spell, base max hit 10, scales with magic strength and fire weakness, no accuracy check
+    if (this.isUsingMeleeStyle() && this.wearing('Fang of the hound')) {
+      let flamesMax = 10;
+      // Scale with magic strength bonus
+      flamesMax = Math.trunc(flamesMax * (1000 + this.player.bonuses.magic_str) / 1000);
+      // Scale with fire elemental weakness
+      if (this.monster.weakness && this.monster.weakness.element === 'fire') {
+        flamesMax = flamesMax + Math.trunc(10 * this.monster.weakness.severity / 100);
+      }
+      // Devil's element adds 30% fire weakness
+      if (this.wearing("Devil's element")) {
+        flamesMax = flamesMax + Math.trunc(10 * 30 / 100);
+      }
+      dist = dist.transform(
+        (h) => new HitDistribution([
+          new WeightedHit(0.95, [h]),
+          new WeightedHit(0.05, [h, new Hitsplat(flamesMax)]),
+        ]),
+        { transformInaccurate: false },
+      );
+    }
+
+    // King's barrage always fires 2 bolts per attack
+    if (this.player.style.type === 'ranged' && this.wearing("King's barrage")) {
+      dist.addDist(HitDistribution.linear(acc, min, max));
     }
 
     if (this.player.spell && this.player.spell.max_hit === 0) {
@@ -1807,6 +1864,19 @@ export default class PlayerVsNPCCalc extends BaseCalc {
     if (this.player.style.type === 'magic'
       && this.wearing('Twinflame staff')
       && ['Bolt', 'Blast', 'Wave'].some((spellClass) => this.player.spell?.name.includes(spellClass) ?? false)) {
+      dist = dist.transform(
+        (h) => HitDistribution.single(1.0, [
+          new Hitsplat(h.damage),
+          new Hitsplat(Math.trunc(h.damage * 4 / 10)),
+        ]),
+      );
+    }
+
+    // Shadowflame quadrant: fires additional spell at 40% damage when using standard spellbook elemental spells
+    if (this.player.style.type === 'magic'
+      && this.wearing('Shadowflame quadrant')
+      && this.player.spell
+      && ['Strike', 'Bolt', 'Blast', 'Wave', 'Surge'].some((spellClass) => this.player.spell?.name.includes(spellClass) ?? false)) {
       dist = dist.transform(
         (h) => HitDistribution.single(1.0, [
           new Hitsplat(h.damage),


### PR DESCRIPTION
## Summary
Adds 6 echo equipment items from the Demonic Pacts League that are currently missing from the calculator, with their combat stats and special effects.

**Note:** The Demonic Pacts League has not yet been released. Stats and effects are based on current OSRS Wiki pages, which are marked as "future content - subject to change". Values may need to be updated upon release.

## Items added
| Item | Slot | Special Effect |
|---|---|---|
| Infernal tecpatl | 2H melee (4t) | Hits twice per attack, 10% demonbane |
| Fang of the hound | 1H dagger (3t) | 5% chance: Flames of Cerberus proc (base 10, scales with magic str + fire weakness) |
| Devil's element | Shield | +30% elemental weakness on all elements |
| Shadowflame quadrant | 1H staff (5t) | Extra spell hit at 40% damage (standard spellbook elemental spells), always uses target's highest elemental weakness |
| King's barrage | 1H crossbow (5t) | Always fires 2 bolts, compatible with enchanted bolt effects |
| Lithic sceptre | 1H powered staff (4t) | Max hit = max(10, floor(magicLvl/3) - 10) |

## Files changed
- `cdn/json/equipment.json` - 6 new item entries (IDs 1000102-1000107)
- `src/lib/BaseCalc.ts` - Infernal tecpatl added to `isWearingTwoHitWeapon()`
- `src/lib/Equipment.ts` - King's barrage ammo compatibility (dragon bolt tier)
- `src/lib/PlayerVsNPCCalc.ts` - All special effects implemented following existing patterns

## Sources
Stats and effects sourced from the [OSRS Wiki](https://oldschool.runescape.wiki) pages for each item.