### PR TITLE
Implement earth spell capstone

### DIFF
--- a/src/lib/BaseCalc.ts
+++ b/src/lib/BaseCalc.ts
@@ -829,12 +829,6 @@ export default class BaseCalc {
     if (leaguesEffects.talent_fire_spell_burn_bounce) {
       this.addIssue(UserIssueType.LEAGUES_SIX_TALENT_UNSUPPORTED, 'Fire Spell Burn (coming soon)');
     }
-    if (leaguesEffects.talent_fire_spell_burn_bounce) {
-      this.addIssue(UserIssueType.LEAGUES_SIX_TALENT_UNSUPPORTED, 'Air Spell Prayer Max Hits (coming soon)');
-    }
-    if (leaguesEffects.talent_earth_scale_defence_stat) {
-      this.addIssue(UserIssueType.LEAGUES_SIX_TALENT_UNSUPPORTED, 'Earth Spell Flat Damage (coming soon)');
-    }
     if (leaguesEffects.talent_regen_magic_level_boost) {
       this.addIssue(UserIssueType.LEAGUES_SIX_TALENT_UNSUPPORTED, 'Regenerate Magic Level Boost (coming soon)');
     }

--- a/src/lib/CalcDetails.ts
+++ b/src/lib/CalcDetails.ts
@@ -129,6 +129,7 @@ export enum DetailKey {
   LEAGUES_MAX_HIT_DISTANCE_MELEE = 'Player distance melee max hit',
   LEAGUES_BLINDBAG_DAMAGE_BONUS = 'Player blindbag uniques max hit',
   LEAGUES_BLINDBAG_CHANCE_UNIQUE = 'Player blindbag uniques chance',
+  LEAGUES_EARTH_SPELL_DEFENCE_BONUS = 'Player talent_earth_scale_defence_stat bonus damage',
 }
 
 export interface DetailEntry {

--- a/src/lib/PlayerVsNPCCalc.ts
+++ b/src/lib/PlayerVsNPCCalc.ts
@@ -1833,6 +1833,12 @@ export default class PlayerVsNPCCalc extends BaseCalc {
       accurateZeroApplicable = false;
     }
 
+    if (leagues.effects.talent_earth_scale_defence_stat && spellement === 'earth') {
+      const defenceLevel = this.player.skills.def + this.player.boosts.def;
+      const bonusDamage = this.trackFactor(DetailKey.LEAGUES_EARTH_SPELL_DEFENCE_BONUS, defenceLevel, [1, 12]);
+      dist = dist.transform(flatAddTransformer(bonusDamage), { transformInaccurate: false });
+    }
+
     // raise accurate 0s to 1
     if (accurateZeroApplicable) {
       dist = dist.transform(
@@ -1973,12 +1979,6 @@ export default class PlayerVsNPCCalc extends BaseCalc {
           new WeightedHit(1.0 - regenChance, [new Hitsplat(h.damage + alwaysRegenerated)]),
         ]), { transformInaccurate: false });
       }
-    }
-
-    if (leagues.effects.talent_earth_scale_defence_stat && spellement === 'earth') {
-      const defenceLevel = this.player.skills.def + this.player.boosts.def;
-      const bonusDamage = this.trackFactor(DetailKey.LEAGUES_EARTH_SPELL_DEFENCE_BONUS, defenceLevel, [1, 12]);
-      dist = dist.transform(flatAddTransformer(bonusDamage), { transformInaccurate: false });
     }
 
     if (process.env.NEXT_PUBLIC_HIT_DIST_SANITY_CHECK) {

--- a/src/lib/PlayerVsNPCCalc.ts
+++ b/src/lib/PlayerVsNPCCalc.ts
@@ -1975,6 +1975,12 @@ export default class PlayerVsNPCCalc extends BaseCalc {
       }
     }
 
+    if (leagues.effects.talent_earth_scale_defence_stat && spellement === 'earth') {
+      const defenceLevel = this.player.skills.def + this.player.boosts.def;
+      const bonusDamage = Math.trunc(defenceLevel / 12);
+      dist.transform(flatAddTransformer(bonusDamage));
+    }
+
     if (process.env.NEXT_PUBLIC_HIT_DIST_SANITY_CHECK) {
       dist.dists.forEach((hitDist, ix) => {
         const sumAccuracy = sum(hitDist.hits, (wh) => wh.probability);

--- a/src/lib/PlayerVsNPCCalc.ts
+++ b/src/lib/PlayerVsNPCCalc.ts
@@ -1977,8 +1977,8 @@ export default class PlayerVsNPCCalc extends BaseCalc {
 
     if (leagues.effects.talent_earth_scale_defence_stat && spellement === 'earth') {
       const defenceLevel = this.player.skills.def + this.player.boosts.def;
-      const bonusDamage = Math.trunc(defenceLevel / 12);
-      dist.transform(flatAddTransformer(bonusDamage));
+      const bonusDamage = this.trackFactor(DetailKey.LEAGUES_EARTH_SPELL_DEFENCE_BONUS, defenceLevel, [1, 12]);
+      dist = dist.transform(flatAddTransformer(bonusDamage), { transformInaccurate: false });
     }
 
     if (process.env.NEXT_PUBLIC_HIT_DIST_SANITY_CHECK) {


### PR DESCRIPTION
Adds 1 flat damage for each 12 defence levels. Based on the wording of "flat damage" I chose to add it after multipiers, similar to flat armour.