### PR TITLE
Implement staves regen fire runes pact

### DIFF
--- a/src/lib/PlayerVsNPCCalc.ts
+++ b/src/lib/PlayerVsNPCCalc.ts
@@ -1834,8 +1834,17 @@ export default class PlayerVsNPCCalc extends BaseCalc {
       dist.addDist(lightDist);
     }
 
-    if (leagues.effects.talent_firerune_regen_damage_boost && this.player.spell) {
-      const fireRunesUsed = COMBAT_SPELL_FIRE_RUNE_COST[this.player.spell.name] ?? 0;
+    if (leagues.effects.talent_firerune_regen_damage_boost) {
+      const regeneratingWithStaff = this.player.equipment.weapon?.category === EquipmentCategory.POWERED_STAFF
+        && this.player.style.stance !== 'Manual Cast'
+        && leagues.effects.talent_regen_stave_charges_fire;
+      let fireRunesUsed = 0;
+      if (this.player.spell) {
+        fireRunesUsed = COMBAT_SPELL_FIRE_RUNE_COST[this.player.spell.name] ?? 0;
+      } else if (regeneratingWithStaff) {
+        fireRunesUsed = 1;
+      }
+
       let regenChance = (leagues.effects.talent_regen_ammo ?? 0) / 100;
       if (fireRunesUsed > 0 && regenChance > 0) {
         let alwaysRegenerated = 0;


### PR DESCRIPTION
Husky [confirmed](https://discord.com/channels/636001942279159830/636001942773956609/1492470302343692409) that this node will increase damage with powered staves in combination with the regen fire rune damage node:

> Whenever your trident generates 1 charge and you have both the "regenerating and fire rune..." and the "whenever a powered staff regenerated a charge, it acts as if a fire rune was regenerated" pacts it will gain +1 damage.
> If your trident two charges by being above 100% regenerating and getting lucky then its +2 damage
