### PR TITLE
Fix distance to enemy for blindbag procs

### DIFF
--- a/src/lib/BaseCalc.ts
+++ b/src/lib/BaseCalc.ts
@@ -27,6 +27,7 @@ export interface CalcOpts {
   usingSpecialAttack?: boolean,
   isLeaguesSubCalc?: boolean,
   isBlindBag?: boolean,
+  blindBagDistance?: number,
   isEcho?: boolean,
   overrides?: {
     accuracy?: number,
@@ -51,6 +52,7 @@ const DEFAULT_OPTS: Required<InternalOpts> = {
   usingSpecialAttack: false,
   isLeaguesSubCalc: false,
   isBlindBag: false,
+  blindBagDistance: 0,
   isEcho: false,
   noInit: false,
   overrides: {},

--- a/src/lib/BaseCalc.ts
+++ b/src/lib/BaseCalc.ts
@@ -52,7 +52,7 @@ const DEFAULT_OPTS: Required<InternalOpts> = {
   usingSpecialAttack: false,
   isLeaguesSubCalc: false,
   isBlindBag: false,
-  blindBagDistance: 0,
+  blindBagDistance: 1,
   isEcho: false,
   noInit: false,
   overrides: {},

--- a/src/lib/PlayerVsNPCCalc.ts
+++ b/src/lib/PlayerVsNPCCalc.ts
@@ -2168,6 +2168,7 @@ export default class PlayerVsNPCCalc extends BaseCalc {
         const subCalc = this.noInitSubCalc(playerWithWeapon, this.monster, {
           loadoutName: `${this.opts.loadoutName}/Blindbag ${weapon.id} (${weapon.name})`,
           isBlindBag: true,
+          blindBagDistance: this.getDistanceToEnemy(),
           isLeaguesSubCalc: true,
         });
 
@@ -2718,6 +2719,11 @@ export default class PlayerVsNPCCalc extends BaseCalc {
   }
 
   private getDistanceToEnemy(): number {
+    if (this.opts.isBlindBag) {
+      // Blindbag hits copy the distance from the main hit.
+      return this.opts.blindBagDistance;
+    }
+
     let distance = this.player.leagues.six.distanceToEnemy;
     if (this.isUsingMeleeStyle()) {
       distance = Math.min(distance, this.getMaxMeleeRange());


### PR DESCRIPTION
Blindbag hits should copy their distance to the enemy from the main hit, instead of applying distance limits based on the blindbag weapon.