### PR TITLE
Filter out Awakened bosses from slayer monsters for slayer buff

### DIFF
--- a/cdn/json/monsters.json
+++ b/cdn/json/monsters.json
@@ -113301,7 +113301,7 @@
     "immunities": {
       "burn": null
     },
-    "is_slayer_monster": true,
+    "is_slayer_monster": false,
     "weakness": null
   },
   {
@@ -114032,7 +114032,7 @@
     "immunities": {
       "burn": null
     },
-    "is_slayer_monster": true,
+    "is_slayer_monster": false,
     "weakness": {
       "element": "earth",
       "severity": 60
@@ -122461,7 +122461,7 @@
     "immunities": {
       "burn": null
     },
-    "is_slayer_monster": true,
+    "is_slayer_monster": false,
     "weakness": {
       "element": "fire",
       "severity": 35

--- a/scripts/generateMonsters.py
+++ b/scripts/generateMonsters.py
@@ -226,7 +226,7 @@ def main():
             'immunities': {
                 'burn': burn_immunity,
             },
-            'is_slayer_monster': v.get('slayer_experience') is not None,
+            'is_slayer_monster': v.get('slayer_experience') is not None and version != 'Awakened',
         }
 
         weakness = v.get('elemental_weakness')

--- a/scripts/generateMonsters.py
+++ b/scripts/generateMonsters.py
@@ -226,7 +226,7 @@ def main():
             'immunities': {
                 'burn': burn_immunity,
             },
-            'is_slayer_monster': v.get('slayer_experience') is not None and version != 'Awakened',
+            'is_slayer_monster': v.get('slayer_experience') is not None and 'Awakened' not in version,
         }
 
         weakness = v.get('elemental_weakness')


### PR DESCRIPTION
Fixes edge-case from #813 , Awakened boss variants award Slayer Experience but Slayer Helmet damage buffs do not work on them.

Awakened Vardorvis example before :
<img width="1392" height="595" alt="image" src="https://github.com/user-attachments/assets/4f260ff9-1133-408c-8dae-bebb59996c26" />

After :
<img width="1364" height="602" alt="image" src="https://github.com/user-attachments/assets/1881960e-2bda-4151-8323-505d01016be6" />


Evidence : 
https://oldschool.runescape.wiki/w/Vardorvis/Strategies#cite_note-2