### PR TITLE
Fix blindbag using cached equipment

### DIFF
--- a/src/lib/BaseCalc.ts
+++ b/src/lib/BaseCalc.ts
@@ -92,7 +92,7 @@ export default class BaseCalc {
     this.baseMonster = monster;
     this.monster = (this.opts.disableMonsterScaling || this.opts.noInit) ? monster : scaleMonster(monster);
 
-    if (!this.opts.noInit) {
+    if (!this.opts.noInit || this.opts.isBlindBag) {
       this.canonicalizeEquipment();
       this.allEquippedItems = Object.values(this.player.equipment).filter((v) => v !== null).flat(1).map((eq: EquipmentPiece | null) => eq?.name || '');
       this.sanitizeInputs();

--- a/src/lib/PlayerVsNPCCalc.ts
+++ b/src/lib/PlayerVsNPCCalc.ts
@@ -2556,7 +2556,9 @@ export default class PlayerVsNPCCalc extends BaseCalc {
   // a computational shortcut for internal class use only
   private noInitSubCalc(p: Player, m: Monster, opts: Partial<InternalOpts> = {}): PlayerVsNPCCalc {
     const subCalc = new PlayerVsNPCCalc(p, m, <InternalOpts>{ ...this.opts, ...opts, noInit: true });
-    subCalc.allEquippedItems = this.allEquippedItems;
+    if (!opts.isBlindBag) {
+      subCalc.allEquippedItems = this.allEquippedItems;
+    }
     subCalc.baseMonster = this.baseMonster;
 
     return subCalc;


### PR DESCRIPTION
This PR fixes a bug where Blindbag weapons were using the cached `allEquippedItems` rather than re-computing that, so any check that the player was wearing that weapon would fail in the `noInitSubCalc`. 