### PR TITLE
Remove item canonicalization for blindbag

### DIFF
--- a/src/lib/BaseCalc.ts
+++ b/src/lib/BaseCalc.ts
@@ -1,7 +1,7 @@
 import { EquipmentPiece, Player } from '@/types/Player';
 import { BurnImmunity, Monster } from '@/types/Monster';
 import {
-  AmmoApplicability, ammoApplicability, getCanonicalEquipment, getCanonicalItem,
+  AmmoApplicability, ammoApplicability, getCanonicalEquipment,
 } from '@/lib/Equipment';
 import UserIssueType from '@/enums/UserIssueType';
 import { MonsterAttribute } from '@/enums/MonsterAttribute';
@@ -147,13 +147,6 @@ export default class BaseCalc {
     this.player = {
       ...this.player,
       equipment: getCanonicalEquipment(this.player.equipment),
-      leagues: {
-        ...this.player.leagues,
-        six: {
-          ...this.player.leagues.six,
-          blindbagWeapons: this.player.leagues.six.blindbagWeapons.map((eq) => getCanonicalItem(eq)),
-        },
-      },
     };
   }
 


### PR DESCRIPTION
`canonicalizeEquipment` was preventing alternate versions of items (such as the holy and sanguine scythes) from registering as different heavy weapons for the purpose of Blindbag calcs. This removes canonicalization entirely for Blindbag weapons. I can't think of anything else this breaks but don't know for sure whether that's the case.