### PR TITLE
Add a basic search box

### DIFF
--- a/src/app/components/player/DemonicPactsLeague.tsx
+++ b/src/app/components/player/DemonicPactsLeague.tsx
@@ -326,7 +326,7 @@ const DemonicPactsLeague: React.FC = observer(() => {
           <div className="flex flex-col h-[80vh]">
             <div className="flex-grow outline outline-gray-500"><SkillTreeDisplay interactive /></div>
             <div
-              className="max-h-64 flex mt-4 h-auto rounded bg-[#1b1612] text-white border border-[#736559] shadow-xl"
+              className="max-h-64 flex mt-4 h-auto rounded bg-[#1b1612] text-white outline outline-[#736559] shadow-xl"
             >
               <SearchBox />
             </div>

--- a/src/app/components/player/DemonicPactsLeague.tsx
+++ b/src/app/components/player/DemonicPactsLeague.tsx
@@ -1,6 +1,8 @@
 import React, { useRef, useState } from 'react';
 import { observer } from 'mobx-react-lite';
 import { IconAlertTriangleFilled, IconEdit } from '@tabler/icons-react';
+import { computed } from 'mobx';
+import localforage from 'localforage';
 import Modal from '@/app/components/generic/Modal';
 import SkillTreeDisplay from '@/app/components/player/demonicPactsLeague/SkillTreeDisplay';
 import CurrentEffects from '@/app/components/player/demonicPactsLeague/CurrentEffects';
@@ -12,10 +14,9 @@ import EquipmentSelect from '@/app/components/player/equipment/EquipmentSelect';
 import ShowIfLeagueEffectEnabled from '@/app/components/player/demonicPactsLeague/ShowIfLeagueEffectEnabled';
 import { getCdnImage } from '@/utils';
 import { EquipmentCategory } from '@/enums/EquipmentCategory';
-import { computed } from 'mobx';
 import UserIssueType from '@/enums/UserIssueType';
-import localforage from 'localforage';
 import { EquipmentPiece } from '@/types/Player';
+import SearchBox from '@/app/components/player/demonicPactsLeague/SearchBox';
 import NumberInput from '../generic/NumberInput';
 
 const weaponCanBeUsedInBlindbag = (eq: EquipmentPiece): boolean => {
@@ -324,6 +325,11 @@ const DemonicPactsLeague: React.FC = observer(() => {
           </div>
           <div className="flex flex-col h-[80vh]">
             <div className="flex-grow outline outline-gray-500"><SkillTreeDisplay interactive /></div>
+            <div
+              className="max-h-64 flex mt-4 h-auto rounded bg-[#1b1612] text-white border border-[#736559] shadow-xl"
+            >
+              <SearchBox />
+            </div>
             <div
               className="max-h-64 flex mt-4 h-auto rounded bg-[#1b1612] text-white outline outline-[#736559] shadow-xl"
             >

--- a/src/app/components/player/demonicPactsLeague/SearchBox.tsx
+++ b/src/app/components/player/demonicPactsLeague/SearchBox.tsx
@@ -1,0 +1,57 @@
+import { observer } from 'mobx-react-lite';
+import { useStore } from '@/state';
+
+const SearchBox = observer(() => {
+  const store = useStore();
+
+  return (
+    <>
+      <div className="px-4 py-2 bg-[#28221d] rounded-t border-b border-[#806f61] shadow-lg flex flex-row gap-4 w-full items-center justify-between hidden md:flex">
+        <h2 className="text-shadow-md">
+          Search Demonic Pacts:
+        </h2>
+        <input
+          type="text"
+          className="form-control rounded flex-grow"
+          value={store.ui.leagues.six.pactsSearchQuery}
+          placeholder="Search pact descriptions..."
+          onChange={(e) => {
+            (store.ui.leagues.six.pactsSearchQuery = e.target.value);
+          }}
+        />
+        <div className="w-28 text-right text-sm">
+          {store.ui.leagues.six.pactsSearchQuery
+                      && (store.nodesMatchingSearch.size > 0
+                        ? `${store.nodesMatchingSearch.size} highlighted`
+                        : 'No matches')}
+        </div>
+      </div>
+      <div className="px-4 py-2 bg-[#28221d] rounded-t border-b border-[#806f61] shadow-lg flex flex-col gap-2 w-full md:hidden items-center">
+        <div className="flex items-center gap-2 w-full">
+          <h2 className="text-shadow-md">
+            Search :
+          </h2>
+          <input
+            type="text"
+            className="form-control rounded flex-grow"
+            value={store.ui.leagues.six.pactsSearchQuery}
+            placeholder="Search pact descriptions..."
+            onChange={(e) => {
+              (store.ui.leagues.six.pactsSearchQuery = e.target.value);
+            }}
+          />
+        </div>
+        {store.ui.leagues.six.pactsSearchQuery
+                      && (
+                      <div className="w-28 text-right text-sm">
+                        {store.nodesMatchingSearch.size > 0
+                          ? `${store.nodesMatchingSearch.size} highlighted`
+                          : 'No matches'}
+                      </div>
+                      )}
+      </div>
+    </>
+  );
+});
+
+export default SearchBox;

--- a/src/app/components/player/demonicPactsLeague/SearchBox.tsx
+++ b/src/app/components/player/demonicPactsLeague/SearchBox.tsx
@@ -6,7 +6,7 @@ const SearchBox = observer(() => {
 
   return (
     <>
-      <div className="px-4 py-2 bg-[#28221d] rounded-t border-b border-[#806f61] shadow-lg flex flex-row gap-4 w-full items-center justify-between hidden md:flex">
+      <div className="px-4 py-2 bg-[#28221d] shadow-lg flex flex-row gap-4 w-full items-center justify-between hidden md:flex">
         <h2 className="text-shadow-md">
           Search Demonic Pacts:
         </h2>
@@ -21,15 +21,15 @@ const SearchBox = observer(() => {
         />
         <div className="w-28 text-right text-sm">
           {store.ui.leagues.six.pactsSearchQuery
-                      && (store.nodesMatchingSearch.size > 0
-                        ? `${store.nodesMatchingSearch.size} highlighted`
-                        : 'No matches')}
+              && (store.nodesMatchingSearch.size > 0
+                ? `${store.nodesMatchingSearch.size} highlighted`
+                : 'No matches')}
         </div>
       </div>
-      <div className="px-4 py-2 bg-[#28221d] rounded-t border-b border-[#806f61] shadow-lg flex flex-col gap-2 w-full md:hidden items-center">
+      <div className="px-4 py-2 bg-[#28221d] shadow-lg flex flex-col gap-2 w-full md:hidden items-center">
         <div className="flex items-center gap-2 w-full">
           <h2 className="text-shadow-md">
-            Search :
+            Search:
           </h2>
           <input
             type="text"

--- a/src/app/components/player/demonicPactsLeague/SkillTreeNode.tsx
+++ b/src/app/components/player/demonicPactsLeague/SkillTreeNode.tsx
@@ -1,6 +1,4 @@
 import { observer } from 'mobx-react-lite';
-import { useStore } from '@/state';
-import { NodeSize, SkillTreeNodeInfo } from '@/app/components/player/demonicPactsLeague/parse_skill_tree_elements';
 import {
   Handle,
   Node,
@@ -8,10 +6,12 @@ import {
   NodeToolbar,
   Position,
 } from '@xyflow/react';
-import { JSONify } from '@/app/components/player/demonicPactsLeague/JSONify';
 import clsx from 'clsx';
-import useKeyPressed from '@/app/components/player/demonicPactsLeague/useKeyPressed';
 import Image from 'next/image';
+import { useStore } from '@/state';
+import { NodeSize, SkillTreeNodeInfo } from '@/app/components/player/demonicPactsLeague/parse_skill_tree_elements';
+import { JSONify } from '@/app/components/player/demonicPactsLeague/JSONify';
+import useKeyPressed from '@/app/components/player/demonicPactsLeague/useKeyPressed';
 import { getBackingIcon, rowIdToTileInfo } from '@/app/components/player/demonicPactsLeague/icons';
 import spriteTiles from '@/app/components/player/demonicPactsLeague/spriteTiles';
 
@@ -84,6 +84,9 @@ export const SkillTreeNode = observer(
     const isHovered = store.leagues.six.hoveredNodeId === id;
 
     const size = nodeSizeToPx[data.skillTreeNodeInfo.node_size];
+    const isMatchingSearch = store.nodesMatchingSearch.has(
+      data.skillTreeNodeInfo.row_id,
+    );
 
     return (
       <div>
@@ -120,6 +123,12 @@ export const SkillTreeNode = observer(
             ).src})`,
           }}
         >
+          {!data.isPreview && isMatchingSearch && (
+            <div
+              className="absolute inset-0 bg-[oklch(72.3%_0.219_149.579)] opacity-50 -z-10 scale-90 rotate-45"
+              aria-hidden="true"
+            />
+          )}
           <Image
             src={getSpriteTile(data.skillTreeNodeInfo.row_id, store.isNodeSelected(id))}
             alt="Pact icon"

--- a/src/state.tsx
+++ b/src/state.tsx
@@ -243,6 +243,11 @@ class GlobalState implements State {
     showShareModal: false,
     username: '',
     isDefensiveReductionsExpanded: false,
+    leagues: {
+      six: {
+        pactsSearchQuery: '',
+      },
+    },
   };
 
   prefs: Preferences = {
@@ -1100,6 +1105,17 @@ class GlobalState implements State {
       }
     }
     return effects;
+  }
+
+  get nodesMatchingSearch(): Set<string> {
+    if (!this.ui.leagues.six.pactsSearchQuery) {
+      return new Set();
+    }
+    return new Set(
+      Object.keys(dbrowDefinitions).filter((id) => dbrowDefinitions[id].name
+        ?.toLowerCase()
+        .includes(this.ui.leagues.six.pactsSearchQuery.toLowerCase())),
+    );
   }
 }
 

--- a/src/types/State.ts
+++ b/src/types/State.ts
@@ -19,6 +19,11 @@ export interface UI {
   showShareModal: boolean;
   username: string;
   isDefensiveReductionsExpanded: boolean;
+  leagues: {
+    six: {
+      pactsSearchQuery: string;
+    };
+  };
 }
 
 /**


### PR DESCRIPTION
Add a basic search box to search node descriptions

Desktop: 
<img width="638" height="677" alt="image" src="https://github.com/user-attachments/assets/df693d0b-fe6d-4929-a551-06e234a8ccb0" />


Mobile: 
<img width="285" height="444" alt="image" src="https://github.com/user-attachments/assets/79b572e1-34db-4214-a64a-736e892d289d" />
