### PR TITLE
Add minion relic DPS calc for Demonic Pacts League

### DIFF
--- a/src/app/components/player/DemonicPactsLeague.tsx
+++ b/src/app/components/player/DemonicPactsLeague.tsx
@@ -116,7 +116,11 @@ const BlindbagSelector = observer(() => {
 const DemonicPactsLeague: React.FC = observer(() => {
   const [showCombatMasteriesUI, setShowCombatMasteriesUI] = useState(false);
   const store = useStore();
-  const { cullingSpree } = store.player.leagues.six;
+  const {
+    cullingSpree,
+    minionEnabled,
+    minionZamorakItemCount,
+  } = store.player.leagues.six;
 
   const fromUrlInput = useRef<HTMLInputElement>(null);
   const fromUrlBtn = useRef<HTMLButtonElement>(null);
@@ -184,6 +188,31 @@ const DemonicPactsLeague: React.FC = observer(() => {
             </>
           )}
         />
+
+        <Toggle
+          checked={minionEnabled}
+          setChecked={(checked) => store.updatePlayer({ leagues: { six: { minionEnabled: checked } } })}
+          label="Minion"
+        />
+
+        <div className="flex items-center gap-2 mt-2">
+          <NumberInput
+            aria-labelledby="minionZamorakItemsLabel"
+            className="form-control w-12 text-centerl"
+            id="minionZamorakItems"
+            min={0}
+            max={5}
+            title="Unique Zamorak items fed to the whistle"
+            value={minionZamorakItemCount}
+            onChange={(value) => {
+              store.updatePlayer({ leagues: { six: { minionZamorakItemCount: value } } });
+            }}
+          />
+
+          <span id="minionZamorakItemsLabel" className="ml-1 text-sm select-none">
+            Unique equippable Zamorak items consumed
+          </span>
+        </div>
 
         <div className="flex items-center gap-2 mt-2">
           <NumberInput

--- a/src/lib/CalcDetails.ts
+++ b/src/lib/CalcDetails.ts
@@ -99,6 +99,7 @@ export enum DetailKey {
   DIST_FINAL = 'Dist final',
   DIST_LEAGUES_BLINDBAG = 'Dist leagues blindbag',
   DIST_LEAGUES_BLINDBAG_RECURSIVE = 'Dist leagues blindbag recursive',
+  DIST_LEAGUES_MINION = 'Dist leagues minion',
   DOT_EXPECTED = 'Damage over time expected',
   DOT_MAX = 'Damage over time max',
   GUARDIANS_DMG_BONUS = 'Guardians hit multiplier',
@@ -133,6 +134,11 @@ export enum DetailKey {
   LEAGUES_BLINDBAG_CHANCE_UNIQUE = 'Player blindbag uniques chance',
   LEAGUES_EARTH_SPELL_DEFENCE_BONUS = 'Player talent_earth_scale_defence_stat bonus damage',
   LEAGUES_LIGHT_WEAPON_DOUBLEHIT_MAX = 'Player light weapon double hit max',
+  LEAGUES_MINION_ACCURACY = 'Player minion accuracy',
+  LEAGUES_MINION_DEFENCE_ROLL = 'Player minion defence roll',
+  LEAGUES_MINION_MAX_HIT = 'Player minion max hit',
+  LEAGUES_MINION_STYLE = 'Player minion style',
+  LEAGUES_MINION_ZAMORAK_ITEMS = 'Player minion Zamorak items',
 }
 
 export interface DetailEntry {

--- a/src/lib/PlayerVsNPCCalc.ts
+++ b/src/lib/PlayerVsNPCCalc.ts
@@ -124,6 +124,13 @@ const UNIMPLEMENTED_SPECS: string[] = [
   'Zamorakian spear',
 ];
 
+const MINION_ATTACK_ROLL = 45_000;
+const MINION_ATTACK_SPEED = 3;
+const MINION_MIN_HIT = 3;
+const MINION_BASE_MAX_HIT = 10;
+const MINION_MAX_HIT_PER_ZAMORAK_ITEM = 2;
+const MINION_MAX_ZAMORAK_ITEMS = 5;
+
 /**
  * Class for computing various player-vs-NPC metrics.
  */
@@ -170,34 +177,175 @@ export default class PlayerVsNPCCalc extends BaseCalc {
       }
     }
 
-    const level = this.track(
-      DetailKey.NPC_DEFENCE_ROLL_LEVEL,
-      defenceStyle === 'magic' && !USES_DEFENCE_LEVEL_FOR_MAGIC_DEFENCE_NPC_IDS.includes(this.monster.id)
-        ? this.monster.skills.magic
-        : this.monster.skills.def,
-    );
+    const defenceData = this.getNpcDefenceRollData(defenceStyle);
+    const level = this.track(DetailKey.NPC_DEFENCE_ROLL_LEVEL, defenceData.level);
     const effectiveLevel = this.trackAdd(DetailKey.NPC_DEFENCE_ROLL_EFFECTIVE_LEVEL, level, 9);
+    const statBonus = this.trackAdd(DetailKey.NPC_DEFENCE_STAT_BONUS, defenceStyle ? defenceData.bonus : 0, 64);
+    let defenceRoll = this.trackFactor(DetailKey.NPC_DEFENCE_ROLL_BASE, effectiveLevel, [statBonus, 1]);
+    if (defenceData.toaMultiplier) {
+      defenceRoll = this.trackFactor(DetailKey.NPC_DEFENCE_ROLL_TOA, defenceRoll, [defenceData.toaMultiplier, 250]);
+    }
+
+    return this.track(DetailKey.NPC_DEFENCE_ROLL_FINAL, defenceRoll);
+  }
+
+  private getNpcDefenceRollForStyle(defenceStyle: CombatStyleType, rangedBonusOverride?: number): number {
+    return this.getNpcDefenceRollData(defenceStyle, rangedBonusOverride).defenceRoll;
+  }
+
+  private getNpcDefenceRollData(defenceStyle: CombatStyleType, rangedBonusOverride?: number): {
+    level: number,
+    bonus: number,
+    defenceRoll: number,
+    toaMultiplier: number | null,
+  } {
+    const level = defenceStyle === 'magic' && !USES_DEFENCE_LEVEL_FOR_MAGIC_DEFENCE_NPC_IDS.includes(this.monster.id)
+      ? this.monster.skills.magic
+      : this.monster.skills.def;
+    const effectiveLevel = level + 9;
 
     let bonus: number;
     if (defenceStyle === 'ranged') {
-      const rangedType = getRangedDamageType(this.player.equipment.weapon!.category);
-      bonus = rangedType === 'mixed'
-        ? Math.trunc((this.monster.defensive.light + this.monster.defensive.standard + this.monster.defensive.heavy) / 3)
-        : this.monster.defensive[rangedType];
+      if (rangedBonusOverride !== undefined) {
+        bonus = rangedBonusOverride;
+      } else {
+        const rangedType = getRangedDamageType(this.player.equipment.weapon!.category);
+        bonus = rangedType === 'mixed'
+          ? Math.trunc((this.monster.defensive.light + this.monster.defensive.standard + this.monster.defensive.heavy) / 3)
+          : this.monster.defensive[rangedType];
+      }
     } else {
       bonus = this.monster.defensive[defenceStyle || 'crush'];
     }
 
-    const statBonus = this.trackAdd(DetailKey.NPC_DEFENCE_STAT_BONUS, defenceStyle ? bonus : 0, 64);
-    let defenceRoll = this.trackFactor(DetailKey.NPC_DEFENCE_ROLL_BASE, effectiveLevel, [statBonus, 1]);
-
     const isCustomMonster = this.monster.id === -1;
+    const toaMultiplier = (((TOMBS_OF_AMASCUT_MONSTER_IDS.includes(this.monster.id) && !KEPHRI_OVERLORD_IDS.includes(this.monster.id)) || isCustomMonster) && this.monster.inputs.toaInvocationLevel)
+      ? 250 + this.monster.inputs.toaInvocationLevel
+      : null;
 
-    if (((TOMBS_OF_AMASCUT_MONSTER_IDS.includes(this.monster.id) && !KEPHRI_OVERLORD_IDS.includes(this.monster.id)) || isCustomMonster) && this.monster.inputs.toaInvocationLevel) {
-      defenceRoll = this.trackFactor(DetailKey.NPC_DEFENCE_ROLL_TOA, defenceRoll, [250 + this.monster.inputs.toaInvocationLevel, 250]);
+    let defenceRoll = effectiveLevel * (bonus + 64);
+    if (toaMultiplier) {
+      defenceRoll = Math.trunc(defenceRoll * toaMultiplier / 250);
     }
 
-    return this.track(DetailKey.NPC_DEFENCE_ROLL_FINAL, defenceRoll);
+    return {
+      level,
+      bonus,
+      defenceRoll,
+      toaMultiplier,
+    };
+  }
+
+  private getMinionHitDistribution(): HitDistribution | null {
+    if (!this.player.leagues.six.minionEnabled) {
+      return null;
+    }
+
+    const zamorakItemCount = Math.max(
+      0,
+      Math.min(this.player.leagues.six.minionZamorakItemCount, MINION_MAX_ZAMORAK_ITEMS),
+    );
+    const maxHit = this.track(
+      DetailKey.LEAGUES_MINION_MAX_HIT,
+      MINION_BASE_MAX_HIT + (zamorakItemCount * MINION_MAX_HIT_PER_ZAMORAK_ITEM),
+    );
+    this.track(DetailKey.LEAGUES_MINION_ZAMORAK_ITEMS, zamorakItemCount);
+
+    const rangedDefenceBonus = Math.min(
+      this.monster.defensive.light,
+      this.monster.defensive.standard,
+      this.monster.defensive.heavy,
+    );
+
+    const candidateDists = (['ranged', 'magic'] as const).map((style) => {
+      const minionCalc = this.getMinionTransformCalc(style);
+      const defenceRoll = style === 'ranged'
+        ? this.getNpcDefenceRollForStyle('ranged', rangedDefenceBonus)
+        : this.getNpcDefenceRollForStyle('magic');
+      const accuracy = BaseCalc.getNormalAccuracyRoll(MINION_ATTACK_ROLL, defenceRoll);
+      const baseDist = HitDistribution.linear(accuracy, MINION_MIN_HIT, maxHit);
+      const finalDist = new AttackDistribution([baseDist])
+        .transform(minionCalc.applyNpcTransforms(style))
+        .singleHitsplat;
+
+      return {
+        style,
+        defenceRoll,
+        accuracy,
+        dist: finalDist,
+      };
+    });
+
+    const bestCandidate = candidateDists.reduce((best, current) => (
+      current.dist.expectedHit() > best.dist.expectedHit() ? current : best
+    ));
+
+    this.track(DetailKey.LEAGUES_MINION_STYLE, bestCandidate.style);
+    this.track(DetailKey.LEAGUES_MINION_DEFENCE_ROLL, bestCandidate.defenceRoll);
+    this.track(DetailKey.LEAGUES_MINION_ACCURACY, bestCandidate.accuracy);
+    this.trackDist(DetailKey.DIST_LEAGUES_MINION, bestCandidate.dist);
+    return bestCandidate.dist;
+  }
+
+  private getMinionTransformCalc(styleType: 'ranged' | 'magic'): PlayerVsNPCCalc {
+    const minionPlayer = <Player>{
+      ...this.player,
+      style: {
+        name: styleType === 'magic' ? 'Minion Magic' : 'Minion Ranged',
+        type: styleType,
+        stance: styleType === 'magic' ? 'Autocast' : 'Accurate',
+      },
+      prayers: [],
+      spell: null,
+      equipment: {
+        head: null,
+        cape: null,
+        neck: null,
+        ammo: null,
+        weapon: null,
+        body: null,
+        shield: null,
+        legs: null,
+        hands: null,
+        feet: null,
+        ring: null,
+      },
+      buffs: {
+        ...this.player.buffs,
+        baAttackerLevel: 0,
+        kandarinDiary: false,
+        markOfDarknessSpell: false,
+        soulreaperStacks: 0,
+        usingSunfireRunes: false,
+      },
+    };
+
+    const minionCalc = new PlayerVsNPCCalc(minionPlayer, this.monster, <InternalOpts>{
+      ...this.opts,
+      isLeaguesSubCalc: true,
+      loadoutName: `${this.opts.loadoutName}/Minion/${styleType}`,
+      noInit: true,
+    });
+    minionCalc.allEquippedItems = [];
+    minionCalc.baseMonster = this.baseMonster;
+    return minionCalc;
+  }
+
+  private getMinionExpectedDamage(): number {
+    return this.getMinionHitDistribution()?.expectedHit() ?? 0;
+  }
+
+  private getMinionDpt(): number {
+    return this.getMinionExpectedDamage() / MINION_ATTACK_SPEED;
+  }
+
+  protected getMinionDelayedHits(): DelayedHit[] {
+    const minionDist = this.getMinionHitDistribution();
+    if (!minionDist) {
+      return [];
+    }
+
+    return minionDist.withProbabilisticDelays(() => [[1.0, MINION_ATTACK_SPEED]]);
   }
 
   private getPlayerMaxMeleeAttackRoll(): number {
@@ -2309,7 +2457,7 @@ export default class PlayerVsNPCCalc extends BaseCalc {
    * Returns the expected damage per tick, based on the player's attack speed.
    */
   public getDpt() {
-    return this.getExpectedDamage() / this.getExpectedAttackSpeed();
+    return (this.getExpectedDamage() / this.getExpectedAttackSpeed()) + this.getMinionDpt();
   }
 
   /**
@@ -2376,6 +2524,10 @@ export default class PlayerVsNPCCalc extends BaseCalc {
    * Returns the average time-to-kill (in seconds) calculation.
    */
   public getTtk() {
+    if (this.player.leagues.six.minionEnabled) {
+      return sum(Array.from(this.getTtkDistribution().entries()), ([ticks, probability]) => ticks * probability) * SECONDS_PER_TICK;
+    }
+
     return this.getHtk() * this.getExpectedAttackSpeed() * SECONDS_PER_TICK;
   }
 
@@ -2472,6 +2624,76 @@ export default class PlayerVsNPCCalc extends BaseCalc {
       for (let hp = 0; hp <= this.monster.skills.hp; hp++) {
         hpHitDists[hp] = this.distAtHp(playerDist, hp);
       }
+    }
+
+    const minionHits = this.getMinionDelayedHits();
+    if (minionHits.length > 0) {
+      const h = iterMax + 20;
+      const w = this.monster.skills.hp + 1;
+      const tickHpsRoot = new Float64Array(h * w);
+      const tickHps = range(0, h)
+        .map((i) => tickHpsRoot.subarray(w * i, w * (i + 1)));
+      tickHps[1][this.monster.inputs.monsterCurrentHp || this.monster.skills.hp] = 1.0;
+
+      const ttks = new Map<number, number>();
+      let epsilon = 1.0;
+
+      for (let tick = 1; tick <= iterMax && epsilon >= TTK_DIST_EPSILON; tick++) {
+        const playerDue = ((tick - 1) % this.getAttackSpeed()) === 0;
+        const minionDue = ((tick - 1) % MINION_ATTACK_SPEED) === 0;
+        const hps = tickHps[tick];
+
+        if (!playerDue && !minionDue) {
+          for (const [hp, hpProb] of hps.entries()) {
+            if (hpProb !== 0) {
+              tickHps[tick + 1][hp] += hpProb;
+            }
+          }
+          continue;
+        }
+
+        for (const [hp, hpProb] of hps.entries()) {
+          if (hpProb === 0) {
+            continue;
+          }
+
+          let combinedDist: HitDistribution | null = null;
+          if (playerDue) {
+            combinedDist = (recalcDistOnHp ? hpHitDists[hp] : playerDist)
+              .map(([wh]) => wh)
+              .reduce((dist, wh) => {
+                dist.addHit(wh);
+                return dist;
+              }, new HitDistribution([]));
+          }
+          if (minionDue) {
+            const minionHitDist = minionHits
+              .map(([wh]) => wh)
+              .reduce((dist, wh) => {
+                dist.addHit(wh);
+                return dist;
+              }, new HitDistribution([]));
+            combinedDist = combinedDist ? combinedDist.zip(minionHitDist).cumulative() : minionHitDist;
+          }
+
+          combinedDist?.hits.forEach((wh) => {
+            const chanceOfAction = wh.probability * hpProb;
+            if (chanceOfAction === 0) {
+              return;
+            }
+
+            const newHp = hp - wh.getSum();
+            if (newHp <= 0) {
+              ttks.set(tick, (ttks.get(tick) || 0) + chanceOfAction);
+              epsilon -= chanceOfAction;
+            } else {
+              tickHps[tick + 1][newHp] += chanceOfAction;
+            }
+          });
+        }
+      }
+
+      return ttks;
     }
 
     // todo dp backwards from 0 hp?

--- a/src/lib/PlayerVsNPCCalc.ts
+++ b/src/lib/PlayerVsNPCCalc.ts
@@ -2628,25 +2628,25 @@ export default class PlayerVsNPCCalc extends BaseCalc {
 
     const minionHits = this.getMinionDelayedHits();
     if (minionHits.length > 0) {
-      const h = iterMax + 20;
-      const w = this.monster.skills.hp + 1;
-      const tickHpsRoot = new Float64Array(h * w);
-      const tickHps = range(0, h)
-        .map((i) => tickHpsRoot.subarray(w * i, w * (i + 1)));
-      tickHps[1][this.monster.inputs.monsterCurrentHp || this.monster.skills.hp] = 1.0;
+      const minionStateHeight = iterMax + 20;
+      const minionStateWidth = this.monster.skills.hp + 1;
+      const minionTickHpsRoot = new Float64Array(minionStateHeight * minionStateWidth);
+      const minionTickHps = range(0, minionStateHeight)
+        .map((i) => minionTickHpsRoot.subarray(minionStateWidth * i, minionStateWidth * (i + 1)));
+      minionTickHps[1][this.monster.inputs.monsterCurrentHp || this.monster.skills.hp] = 1.0;
 
-      const ttks = new Map<number, number>();
-      let epsilon = 1.0;
+      const minionTtks = new Map<number, number>();
+      let minionEpsilon = 1.0;
 
-      for (let tick = 1; tick <= iterMax && epsilon >= TTK_DIST_EPSILON; tick++) {
+      for (let tick = 1; tick <= iterMax && minionEpsilon >= TTK_DIST_EPSILON; tick++) {
         const playerDue = ((tick - 1) % this.getAttackSpeed()) === 0;
         const minionDue = ((tick - 1) % MINION_ATTACK_SPEED) === 0;
-        const hps = tickHps[tick];
+        const hps = minionTickHps[tick];
 
         if (!playerDue && !minionDue) {
           for (const [hp, hpProb] of hps.entries()) {
             if (hpProb !== 0) {
-              tickHps[tick + 1][hp] += hpProb;
+              minionTickHps[tick + 1][hp] += hpProb;
             }
           }
           continue;
@@ -2676,24 +2676,28 @@ export default class PlayerVsNPCCalc extends BaseCalc {
             combinedDist = combinedDist ? combinedDist.zip(minionHitDist).cumulative() : minionHitDist;
           }
 
-          combinedDist?.hits.forEach((wh) => {
+          if (!combinedDist) {
+            continue;
+          }
+
+          for (const wh of combinedDist.hits) {
             const chanceOfAction = wh.probability * hpProb;
             if (chanceOfAction === 0) {
-              return;
+              continue;
             }
 
             const newHp = hp - wh.getSum();
             if (newHp <= 0) {
-              ttks.set(tick, (ttks.get(tick) || 0) + chanceOfAction);
-              epsilon -= chanceOfAction;
+              minionTtks.set(tick, (minionTtks.get(tick) || 0) + chanceOfAction);
+              minionEpsilon -= chanceOfAction;
             } else {
-              tickHps[tick + 1][newHp] += chanceOfAction;
+              minionTickHps[tick + 1][newHp] += chanceOfAction;
             }
-          });
+          }
         }
       }
 
-      return ttks;
+      return minionTtks;
     }
 
     // todo dp backwards from 0 hp?

--- a/src/state.tsx
+++ b/src/state.tsx
@@ -143,6 +143,8 @@ export const generateEmptyPlayer = (name?: string): Player => ({
     six: {
       selectedNodeIds: new Set<string>(['node1']),
       effects: {},
+      minionEnabled: false,
+      minionZamorakItemCount: 0,
       distanceToEnemy: 1,
       enemyPrayers: {
         melee: false,

--- a/src/tests/TtkDist.test.ts
+++ b/src/tests/TtkDist.test.ts
@@ -6,8 +6,10 @@ import PlayerVsNPCCalc from '@/lib/PlayerVsNPCCalc';
 import { getTestMonster, getTestPlayer } from '@/tests/utils/TestUtils';
 
 class TestMinionTtkCalc extends PlayerVsNPCCalc {
+  private readonly delayedHits = HitDistribution.single(1.0, [new Hitsplat(1)]).withProbabilisticDelays(() => [[1.0, 3]]);
+
   protected override getMinionDelayedHits() {
-    return HitDistribution.single(1.0, [new Hitsplat(1)]).withProbabilisticDelays(() => [[1.0, 3]]);
+    return this.delayedHits;
   }
 }
 

--- a/src/tests/TtkDist.test.ts
+++ b/src/tests/TtkDist.test.ts
@@ -5,6 +5,12 @@ import {
 import PlayerVsNPCCalc from '@/lib/PlayerVsNPCCalc';
 import { getTestMonster, getTestPlayer } from '@/tests/utils/TestUtils';
 
+class TestMinionTtkCalc extends PlayerVsNPCCalc {
+  protected override getMinionDelayedHits() {
+    return HitDistribution.single(1.0, [new Hitsplat(1)]).withProbabilisticDelays(() => [[1.0, 3]]);
+  }
+}
+
 describe('variable attack speeds should not merge states from different timelines', () => {
   test('2hp, 50% accuracy, 3:4 guarantee, 1 max', () => {
     const dist = new AttackDistribution([new HitDistribution([
@@ -100,5 +106,30 @@ describe('variable attack speeds should not merge states from different timeline
       .toBeCloseTo(4.99e-05);
     expect(result.get(83))
       .toBeCloseTo(2.64e-05);
+  });
+
+  test('minion and player hits can combine on the same tick', () => {
+    const m = getTestMonster('Abyssal demon', 'Standard', {
+      skills: {
+        hp: 2,
+      },
+    });
+    const p = getTestPlayer(m, {
+      attackSpeed: 4,
+      leagues: {
+        six: {
+          minionEnabled: true,
+          minionZamorakItemCount: 0,
+        },
+      },
+    });
+    const calc = new TestMinionTtkCalc(p, m);
+    calc.getDistribution = () => new AttackDistribution([
+      HitDistribution.single(1.0, [new Hitsplat(1)]),
+    ]);
+
+    const result = calc.getTtkDistribution();
+    expect(result.get(1))
+      .toBeCloseTo(1.0);
   });
 });

--- a/src/tests/calc/Minion.test.ts
+++ b/src/tests/calc/Minion.test.ts
@@ -1,0 +1,110 @@
+import { describe, expect, test } from '@jest/globals';
+import PlayerVsNPCCalc from '@/lib/PlayerVsNPCCalc';
+import { DetailKey } from '@/lib/CalcDetails';
+import {
+  findEquipment,
+  findResult,
+  getTestMonster,
+  getTestPlayer,
+} from '@/tests/utils/TestUtils';
+
+const getMinionDpt = (calc: PlayerVsNPCCalc): number => calc.getDpt() - (calc.getExpectedDamage() / calc.getExpectedAttackSpeed());
+
+describe('Minion', () => {
+  test('chooses the weaker of ranged or magic defences', () => {
+    const m = getTestMonster('Abyssal demon', 'Standard', {
+      defensive: {
+        light: 220,
+        standard: 220,
+        heavy: 220,
+        magic: -20,
+      },
+    });
+    const p = getTestPlayer(m, {
+      equipment: {
+        weapon: findEquipment('Bronze dagger'),
+      },
+      leagues: {
+        six: {
+          minionEnabled: true,
+          minionZamorakItemCount: 0,
+        },
+      },
+    });
+
+    const calc = new PlayerVsNPCCalc(p, m, { detailedOutput: true });
+    calc.getDps();
+
+    expect(findResult(calc.details, DetailKey.LEAGUES_MINION_STYLE)).toBe('magic');
+  });
+
+  test('gains max hit from consumed Zamorak items', () => {
+    const m = getTestMonster('Abyssal demon', 'Standard');
+    const playerOverrides = {
+      equipment: {
+        weapon: findEquipment('Bronze dagger'),
+      },
+      leagues: {
+        six: {
+          minionEnabled: true,
+        },
+      },
+    };
+
+    const baseCalc = new PlayerVsNPCCalc(getTestPlayer(m, {
+      ...playerOverrides,
+      leagues: {
+        six: {
+          ...playerOverrides.leagues.six,
+          minionZamorakItemCount: 0,
+        },
+      },
+    }), m, { detailedOutput: true });
+    baseCalc.getDps();
+
+    const upgradedCalc = new PlayerVsNPCCalc(getTestPlayer(m, {
+      ...playerOverrides,
+      leagues: {
+        six: {
+          ...playerOverrides.leagues.six,
+          minionZamorakItemCount: 5,
+        },
+      },
+    }), m, { detailedOutput: true });
+    upgradedCalc.getDps();
+
+    expect(findResult(baseCalc.details, DetailKey.LEAGUES_MINION_MAX_HIT)).toBe(10);
+    expect(findResult(upgradedCalc.details, DetailKey.LEAGUES_MINION_MAX_HIT)).toBe(20);
+    expect(upgradedCalc.getDps()).toBeGreaterThan(baseCalc.getDps());
+  });
+
+  test('does not inherit player bolt effects', () => {
+    const m = getTestMonster('Abyssal demon', 'Standard');
+    const neutralCalc = new PlayerVsNPCCalc(getTestPlayer(m, {
+      equipment: {
+        weapon: findEquipment('Bronze dagger'),
+      },
+      leagues: {
+        six: {
+          minionEnabled: true,
+          minionZamorakItemCount: 0,
+        },
+      },
+    }), m);
+
+    const boltCalc = new PlayerVsNPCCalc(getTestPlayer(m, {
+      equipment: {
+        weapon: findEquipment('Rune crossbow'),
+        ammo: findEquipment('Ruby bolts (e)'),
+      },
+      leagues: {
+        six: {
+          minionEnabled: true,
+          minionZamorakItemCount: 0,
+        },
+      },
+    }), m);
+
+    expect(getMinionDpt(boltCalc)).toBeCloseTo(getMinionDpt(neutralCalc));
+  });
+});

--- a/src/tests/calc/Minion.test.ts
+++ b/src/tests/calc/Minion.test.ts
@@ -1,18 +1,19 @@
-import { describe, expect, test } from '@jest/globals';
-import PlayerVsNPCCalc from '@/lib/PlayerVsNPCCalc';
-import { DetailKey } from '@/lib/CalcDetails';
+import { describe, expect, test } from "@jest/globals";
+import PlayerVsNPCCalc from "@/lib/PlayerVsNPCCalc";
+import { DetailKey } from "@/lib/CalcDetails";
 import {
   findEquipment,
   findResult,
   getTestMonster,
   getTestPlayer,
-} from '@/tests/utils/TestUtils';
+} from "@/tests/utils/TestUtils";
 
-const getMinionDpt = (calc: PlayerVsNPCCalc): number => calc.getDpt() - (calc.getExpectedDamage() / calc.getExpectedAttackSpeed());
+const getMinionDpt = (calc: PlayerVsNPCCalc): number =>
+  calc.getDpt() - calc.getExpectedDamage() / calc.getExpectedAttackSpeed();
 
-describe('Minion', () => {
-  test('chooses the weaker of ranged or magic defences', () => {
-    const m = getTestMonster('Abyssal demon', 'Standard', {
+describe("Minion", () => {
+  test("chooses the weaker of ranged or magic defences", () => {
+    const m = getTestMonster("Abyssal demon", "Standard", {
       defensive: {
         light: 220,
         standard: 220,
@@ -22,7 +23,7 @@ describe('Minion', () => {
     });
     const p = getTestPlayer(m, {
       equipment: {
-        weapon: findEquipment('Bronze dagger'),
+        weapon: findEquipment("Bronze dagger"),
       },
       leagues: {
         six: {
@@ -35,14 +36,16 @@ describe('Minion', () => {
     const calc = new PlayerVsNPCCalc(p, m, { detailedOutput: true });
     calc.getDps();
 
-    expect(findResult(calc.details, DetailKey.LEAGUES_MINION_STYLE)).toBe('magic');
+    expect(findResult(calc.details, DetailKey.LEAGUES_MINION_STYLE)).toBe(
+      "magic",
+    );
   });
 
-  test('gains max hit from consumed Zamorak items', () => {
-    const m = getTestMonster('Abyssal demon', 'Standard');
+  test("gains max hit from consumed Zamorak items", () => {
+    const m = getTestMonster("Abyssal demon", "Standard");
     const playerOverrides = {
       equipment: {
-        weapon: findEquipment('Bronze dagger'),
+        weapon: findEquipment("Bronze dagger"),
       },
       leagues: {
         six: {
@@ -51,59 +54,77 @@ describe('Minion', () => {
       },
     };
 
-    const baseCalc = new PlayerVsNPCCalc(getTestPlayer(m, {
-      ...playerOverrides,
-      leagues: {
-        six: {
-          ...playerOverrides.leagues.six,
-          minionZamorakItemCount: 0,
+    const baseCalc = new PlayerVsNPCCalc(
+      getTestPlayer(m, {
+        ...playerOverrides,
+        leagues: {
+          six: {
+            ...playerOverrides.leagues.six,
+            minionZamorakItemCount: 0,
+          },
         },
-      },
-    }), m, { detailedOutput: true });
+      }),
+      m,
+      { detailedOutput: true },
+    );
     baseCalc.getDps();
 
-    const upgradedCalc = new PlayerVsNPCCalc(getTestPlayer(m, {
-      ...playerOverrides,
-      leagues: {
-        six: {
-          ...playerOverrides.leagues.six,
-          minionZamorakItemCount: 5,
+    const upgradedCalc = new PlayerVsNPCCalc(
+      getTestPlayer(m, {
+        ...playerOverrides,
+        leagues: {
+          six: {
+            ...playerOverrides.leagues.six,
+            minionZamorakItemCount: 5,
+          },
         },
-      },
-    }), m, { detailedOutput: true });
+      }),
+      m,
+      { detailedOutput: true },
+    );
     upgradedCalc.getDps();
 
-    expect(findResult(baseCalc.details, DetailKey.LEAGUES_MINION_MAX_HIT)).toBe(10);
-    expect(findResult(upgradedCalc.details, DetailKey.LEAGUES_MINION_MAX_HIT)).toBe(20);
+    expect(findResult(baseCalc.details, DetailKey.LEAGUES_MINION_MAX_HIT)).toBe(
+      10,
+    );
+    expect(
+      findResult(upgradedCalc.details, DetailKey.LEAGUES_MINION_MAX_HIT),
+    ).toBe(20);
     expect(upgradedCalc.getDps()).toBeGreaterThan(baseCalc.getDps());
   });
 
-  test('does not inherit player bolt effects', () => {
-    const m = getTestMonster('Abyssal demon', 'Standard');
-    const neutralCalc = new PlayerVsNPCCalc(getTestPlayer(m, {
-      equipment: {
-        weapon: findEquipment('Bronze dagger'),
-      },
-      leagues: {
-        six: {
-          minionEnabled: true,
-          minionZamorakItemCount: 0,
+  test("does not inherit player bolt effects", () => {
+    const m = getTestMonster("Abyssal demon", "Standard");
+    const neutralCalc = new PlayerVsNPCCalc(
+      getTestPlayer(m, {
+        equipment: {
+          weapon: findEquipment("Bronze dagger"),
         },
-      },
-    }), m);
+        leagues: {
+          six: {
+            minionEnabled: true,
+            minionZamorakItemCount: 0,
+          },
+        },
+      }),
+      m,
+    );
 
-    const boltCalc = new PlayerVsNPCCalc(getTestPlayer(m, {
-      equipment: {
-        weapon: findEquipment('Rune crossbow'),
-        ammo: findEquipment('Ruby bolts (e)'),
-      },
-      leagues: {
-        six: {
-          minionEnabled: true,
-          minionZamorakItemCount: 0,
+    const boltCalc = new PlayerVsNPCCalc(
+      getTestPlayer(m, {
+        equipment: {
+          weapon: findEquipment("Rune crossbow"),
+          ammo: findEquipment("Ruby bolts (e)"),
         },
-      },
-    }), m);
+        leagues: {
+          six: {
+            minionEnabled: true,
+            minionZamorakItemCount: 0,
+          },
+        },
+      }),
+      m,
+    );
 
     expect(getMinionDpt(boltCalc)).toBeCloseTo(getMinionDpt(neutralCalc));
   });

--- a/src/tests/calc/Minion.test.ts
+++ b/src/tests/calc/Minion.test.ts
@@ -1,19 +1,18 @@
-import { describe, expect, test } from "@jest/globals";
-import PlayerVsNPCCalc from "@/lib/PlayerVsNPCCalc";
-import { DetailKey } from "@/lib/CalcDetails";
+import { describe, expect, test } from '@jest/globals';
+import PlayerVsNPCCalc from '@/lib/PlayerVsNPCCalc';
+import { DetailKey } from '@/lib/CalcDetails';
 import {
   findEquipment,
   findResult,
   getTestMonster,
   getTestPlayer,
-} from "@/tests/utils/TestUtils";
+} from '@/tests/utils/TestUtils';
 
-const getMinionDpt = (calc: PlayerVsNPCCalc): number =>
-  calc.getDpt() - calc.getExpectedDamage() / calc.getExpectedAttackSpeed();
+const getMinionDpt = (calc: PlayerVsNPCCalc): number => calc.getDpt() - calc.getExpectedDamage() / calc.getExpectedAttackSpeed();
 
-describe("Minion", () => {
-  test("chooses the weaker of ranged or magic defences", () => {
-    const m = getTestMonster("Abyssal demon", "Standard", {
+describe('Minion', () => {
+  test('chooses the weaker of ranged or magic defences', () => {
+    const m = getTestMonster('Abyssal demon', 'Standard', {
       defensive: {
         light: 220,
         standard: 220,
@@ -23,7 +22,7 @@ describe("Minion", () => {
     });
     const p = getTestPlayer(m, {
       equipment: {
-        weapon: findEquipment("Bronze dagger"),
+        weapon: findEquipment('Bronze dagger'),
       },
       leagues: {
         six: {
@@ -36,16 +35,14 @@ describe("Minion", () => {
     const calc = new PlayerVsNPCCalc(p, m, { detailedOutput: true });
     calc.getDps();
 
-    expect(findResult(calc.details, DetailKey.LEAGUES_MINION_STYLE)).toBe(
-      "magic",
-    );
+    expect(findResult(calc.details, DetailKey.LEAGUES_MINION_STYLE)).toBe('magic');
   });
 
-  test("gains max hit from consumed Zamorak items", () => {
-    const m = getTestMonster("Abyssal demon", "Standard");
+  test('gains max hit from consumed Zamorak items', () => {
+    const m = getTestMonster('Abyssal demon', 'Standard');
     const playerOverrides = {
       equipment: {
-        weapon: findEquipment("Bronze dagger"),
+        weapon: findEquipment('Bronze dagger'),
       },
       leagues: {
         six: {
@@ -93,12 +90,12 @@ describe("Minion", () => {
     expect(upgradedCalc.getDps()).toBeGreaterThan(baseCalc.getDps());
   });
 
-  test("does not inherit player bolt effects", () => {
-    const m = getTestMonster("Abyssal demon", "Standard");
+  test('does not inherit player bolt effects', () => {
+    const m = getTestMonster('Abyssal demon', 'Standard');
     const neutralCalc = new PlayerVsNPCCalc(
       getTestPlayer(m, {
         equipment: {
-          weapon: findEquipment("Bronze dagger"),
+          weapon: findEquipment('Bronze dagger'),
         },
         leagues: {
           six: {
@@ -113,8 +110,8 @@ describe("Minion", () => {
     const boltCalc = new PlayerVsNPCCalc(
       getTestPlayer(m, {
         equipment: {
-          weapon: findEquipment("Rune crossbow"),
-          ammo: findEquipment("Ruby bolts (e)"),
+          weapon: findEquipment('Rune crossbow'),
+          ammo: findEquipment('Ruby bolts (e)'),
         },
         leagues: {
           six: {

--- a/src/types/Player.ts
+++ b/src/types/Player.ts
@@ -85,6 +85,10 @@ export interface LeaguesState {
 
   effects: { [k in LeaguesEffect]?: number };
 
+  minionEnabled: boolean;
+
+  minionZamorakItemCount: number;
+
   distanceToEnemy: number;
 
   enemyPrayers: {


### PR DESCRIPTION
- Introduced minion state management in player leagues
- Added UI toggle for minion activation and input for Zamorak items
- Updated calculations for minion damage and attack distribution
- Implemented tests for minion interactions and damage calculations

<img width="1487" height="907" alt="image" src="https://github.com/user-attachments/assets/608eb5bc-ad70-4029-8347-9fadfc8a7db8" />

<img width="1493" height="900" alt="image" src="https://github.com/user-attachments/assets/699a4c6f-c7ac-4c68-be69-521e6ae008bc" />

<img width="1493" height="897" alt="image" src="https://github.com/user-attachments/assets/7d6a6d94-ddac-4b8c-a220-a81629b16adc" />
