### PR TITLE
Demonic pacts executioner

### DIFF
--- a/src/app/components/player/DemonicPactsLeague.tsx
+++ b/src/app/components/player/DemonicPactsLeague.tsx
@@ -116,7 +116,7 @@ const BlindbagSelector = observer(() => {
 const DemonicPactsLeague: React.FC = observer(() => {
   const [showCombatMasteriesUI, setShowCombatMasteriesUI] = useState(false);
   const store = useStore();
-  const { cullingSpree } = store.player.leagues.six;
+  const { cullingSpree, executionerEnabled } = store.player.leagues.six;
 
   const fromUrlInput = useRef<HTMLInputElement>(null);
   const fromUrlBtn = useRef<HTMLButtonElement>(null);
@@ -181,6 +181,24 @@ const DemonicPactsLeague: React.FC = observer(() => {
               />
               {' '}
               Culling Spree
+            </>
+          )}
+        />
+
+        <Toggle
+          checked={executionerEnabled}
+          setChecked={(checked) => store.updatePlayer({ leagues: { six: { executionerEnabled: checked } } })}
+          label={(
+            <>
+              Executioner
+              {' '}
+              <span
+                className="align-super underline decoration-dotted cursor-help text-xs text-gray-300"
+                data-tooltip-id="tooltip"
+                data-tooltip-content="Uses Sage's axe execution logic for TTK and the parenthetical DPS value."
+              >
+                ?
+              </span>
             </>
           )}
         />

--- a/src/app/components/results/PlayerVsNPCResultsTable.tsx
+++ b/src/app/components/results/PlayerVsNPCResultsTable.tsx
@@ -43,6 +43,10 @@ const calcKeyToString = (value: number, calcKey: keyof PlayerVsNPCCalculatedLoad
 };
 
 const calcDpsString = (value: number, executionerValue?: number): React.ReactNode => {
+  if (!isDefined(value)) {
+    return (<p className="text-sm">---</p>);
+  }
+
   if (!isDefined(executionerValue)) {
     return value.toFixed(DPS_PRECISION);
   }

--- a/src/app/components/results/PlayerVsNPCResultsTable.tsx
+++ b/src/app/components/results/PlayerVsNPCResultsTable.tsx
@@ -42,6 +42,24 @@ const calcKeyToString = (value: number, calcKey: keyof PlayerVsNPCCalculatedLoad
   }
 };
 
+const calcDpsString = (value: number, executionerValue?: number): React.ReactNode => {
+  if (!isDefined(executionerValue)) {
+    return value.toFixed(DPS_PRECISION);
+  }
+
+  return (
+    <>
+      {value.toFixed(DPS_PRECISION)}
+      {' '}
+      <span className="text-xs text-gray-500 dark:text-gray-300">
+        (
+        {executionerValue.toFixed(DPS_PRECISION)}
+        )
+      </span>
+    </>
+  );
+};
+
 const ResultRowHeader: React.FC<PropsWithChildren> = (props) => {
   const { children } = props;
 
@@ -87,10 +105,19 @@ const ResultRow: React.FC<PropsWithChildren<IResultRowProps>> = observer((props)
           ) : undefined;
       }
 
+      let displayValue: string | React.ReactNode;
+      if (hasResults) {
+        displayValue = calcKey === 'dps'
+          ? calcDpsString(value, l.executionerDps)
+          : calcKeyToString(value, calcKey);
+      } else {
+        displayValue = <Spinner className="w-3" />;
+      }
+
       return (
         // eslint-disable-next-line react/no-array-index-key
         <th className={`text-center w-28 border-r ${((Object.values(loadouts).length > 1) && bestValue === value) ? 'dark:text-green-200 text-green-800' : 'dark:text-body-200 text-black'}`} key={i}>
-          {hasResults ? calcKeyToString(value, calcKey) : (<Spinner className="w-3" />)}
+          {displayValue}
         </th>
       );
     });

--- a/src/lib/PlayerVsNPCCalc.ts
+++ b/src/lib/PlayerVsNPCCalc.ts
@@ -61,6 +61,7 @@ import {
   USES_DEFENCE_LEVEL_FOR_MAGIC_DEFENCE_NPC_IDS,
   VERZIK_P1_IDS,
   VESPULA_IDS,
+  YAMA_IDS,
   YAMA_VOID_FLARE_IDS,
   ZULRAH_IDS,
 } from '@/lib/constants';
@@ -2319,6 +2320,46 @@ export default class PlayerVsNPCCalc extends BaseCalc {
     return this.getDpt() / SECONDS_PER_TICK;
   }
 
+  private isExecutionerEnabled() {
+    return this.player.leagues.six.executionerEnabled && !YAMA_IDS.includes(this.monster.id);
+  }
+
+  private getExecutionerThresholdHp() {
+    return Math.trunc(this.monster.skills.hp / 5);
+  }
+
+  private canUseExecutionerAtHp(hp: number) {
+    return this.isExecutionerEnabled()
+      && this.getExecutionerThresholdHp() > 0
+      && hp > 0
+      && hp <= this.getExecutionerThresholdHp();
+  }
+
+  private getExecutionerDistAtHp(hp: number): DelayedHit[] {
+    return new HitDistribution([new WeightedHit(1.0, [new Hitsplat(hp)])])
+      .transform(this.applyNpcTransforms('ranged'))
+      .cumulative()
+      .withProbabilisticDelays(this.getWeaponDelayProvider());
+  }
+
+  private static getDistributionTtk(ttkDist: Map<number, number>) {
+    return sum(Array.from(ttkDist.entries()), ([ticks, probability]) => ticks * probability) * SECONDS_PER_TICK;
+  }
+
+  private distHasNonExecutionerCurrentHpDependency(loadout: Player, monster: Monster): boolean {
+    if (monster.name === 'Vardorvis') {
+      return true;
+    }
+    if (loadout.equipment.weapon?.name.includes('rossbow') && this.wearing(['Ruby bolts (e)', 'Ruby dragon bolts (e)'])) {
+      return true;
+    }
+    if (this.wearing('Keris partisan of the sun') && TOMBS_OF_AMASCUT_MONSTER_IDS.includes(monster.id)) {
+      return true;
+    }
+
+    return false;
+  }
+
   /**
    * Returns the amount of time (in ticks) that the user can maintain their prayers before running out of prayer points.
    * Does not account for flicking or toggling prayers.
@@ -2376,7 +2417,25 @@ export default class PlayerVsNPCCalc extends BaseCalc {
    * Returns the average time-to-kill (in seconds) calculation.
    */
   public getTtk() {
+    if (this.isExecutionerEnabled()) {
+      return PlayerVsNPCCalc.getDistributionTtk(this.getTtkDistribution());
+    }
+
     return this.getHtk() * this.getExpectedAttackSpeed() * SECONDS_PER_TICK;
+  }
+
+  public getExecutionerDps(): number | undefined {
+    if (!this.isExecutionerEnabled()) {
+      return undefined;
+    }
+
+    const ttk = this.getTtk();
+    if (!ttk) {
+      return undefined;
+    }
+
+    const startHp = this.monster.inputs.monsterCurrentHp || this.monster.skills.hp;
+    return startHp / ttk;
   }
 
   public getSpecDps(): number {
@@ -2427,8 +2486,9 @@ export default class PlayerVsNPCCalc extends BaseCalc {
    * it is an object where keys are tick counts and values are probabilities.
    */
   public getTtkDistribution(): Map<number, number> {
-    if (this.getDistribution()
-      .getExpectedDamage() === 0) { // todo thralls, allow thrall-only compute?
+    const startHp = this.monster.inputs.monsterCurrentHp || this.monster.skills.hp;
+    if (this.getDistribution().getExpectedDamage() === 0
+      && !this.canUseExecutionerAtHp(startHp)) { // todo thralls, allow thrall-only compute?
       return new Map<number, number>();
     }
 
@@ -2456,7 +2516,7 @@ export default class PlayerVsNPCCalc extends BaseCalc {
     const tickHpsRoot = new Float64Array(h * w);
     const tickHps = range(0, h)
       .map((i) => tickHpsRoot.subarray(w * i, w * (i + 1)));
-    tickHps[1][this.monster.inputs.monsterCurrentHp || this.monster.skills.hp] = 1.0;
+    tickHps[1][startHp] = 1.0;
 
     // output map, will be converted at the end
     const ttks = new Map<number, number>();
@@ -2522,11 +2582,16 @@ export default class PlayerVsNPCCalc extends BaseCalc {
   }
 
   distAtHp(baseDist: DelayedHit[], hp: number): DelayedHit[] {
+    if (this.canUseExecutionerAtHp(hp)) {
+      return this.getExecutionerDistAtHp(hp);
+    }
+
     if (this.opts.disableMonsterScaling) {
       return baseDist;
     }
 
-    if (!this.distIsCurrentHpDependent(this.player, this.monster) || hp === this.monster.inputs.monsterCurrentHp) {
+    if (!this.distHasNonExecutionerCurrentHpDependency(this.player, this.monster)
+      || hp === this.monster.inputs.monsterCurrentHp) {
       return baseDist;
     }
 
@@ -2582,17 +2647,9 @@ export default class PlayerVsNPCCalc extends BaseCalc {
   }
 
   public distIsCurrentHpDependent(loadout: Player, monster: Monster): boolean {
-    if (monster.name === 'Vardorvis') {
-      return true;
-    }
-    if (loadout.equipment.weapon?.name.includes('rossbow') && this.wearing(['Ruby bolts (e)', 'Ruby dragon bolts (e)'])) {
-      return true;
-    }
-    if (this.wearing('Keris partisan of the sun') && TOMBS_OF_AMASCUT_MONSTER_IDS.includes(monster.id)) {
-      return true;
-    }
-
-    return false;
+    return this.canUseExecutionerAtHp(monster.inputs.monsterCurrentHp || monster.skills.hp)
+      || this.isExecutionerEnabled()
+      || this.distHasNonExecutionerCurrentHpDependency(loadout, monster);
   }
 
   private static tbowScaling = (current: number, magic: number, accuracyMode: boolean): number => {

--- a/src/state.tsx
+++ b/src/state.tsx
@@ -143,6 +143,7 @@ export const generateEmptyPlayer = (name?: string): Player => ({
     six: {
       selectedNodeIds: new Set<string>(['node1']),
       effects: {},
+      executionerEnabled: false,
       distanceToEnemy: 1,
       enemyPrayers: {
         melee: false,

--- a/src/tests/CombatCalc.test.ts
+++ b/src/tests/CombatCalc.test.ts
@@ -13,3 +13,27 @@ test('Empty player against abyssal demon', () => {
   expect(result.npcDefRoll).toBe(12096);
   expect(result.accuracy * 100).toBeCloseTo(29.10, ACCURACY_PRECISION);
 });
+
+test('Executioner keeps base DPS while improving TTK at threshold HP', () => {
+  const monster = getTestMonster('Abyssal demon', 'Standard', {
+    inputs: {
+      monsterCurrentHp: 30,
+    },
+  });
+  const basePlayer = getTestPlayer(monster);
+  const executionerPlayer = getTestPlayer(monster, {
+    leagues: {
+      six: {
+        executionerEnabled: true,
+      },
+    },
+  });
+
+  const baseResult = calculatePlayerVsNpc(monster, basePlayer);
+  const executionerResult = calculatePlayerVsNpc(monster, executionerPlayer);
+
+  expect(executionerResult.dps).toBeCloseTo(baseResult.dps, DPS_PRECISION);
+  expect(executionerResult.ttk).toBeLessThan(baseResult.ttk);
+  expect(executionerResult.executionerDps).toBeDefined();
+  expect(executionerResult.executionerDps).toBeGreaterThan(executionerResult.dps);
+});

--- a/src/tests/TtkDist.test.ts
+++ b/src/tests/TtkDist.test.ts
@@ -1,9 +1,10 @@
 import { expect, test, describe } from '@jest/globals';
 import {
-  AttackDistribution, HitDistribution, Hitsplat, WeightedHit,
+  AttackDistribution, divisionTransformer, HitDistribution, Hitsplat, WeightedHit,
 } from '@/lib/HitDist';
 import PlayerVsNPCCalc from '@/lib/PlayerVsNPCCalc';
 import { getTestMonster, getTestPlayer } from '@/tests/utils/TestUtils';
+import { YAMA_IDS } from '@/lib/constants';
 
 describe('variable attack speeds should not merge states from different timelines', () => {
   test('2hp, 50% accuracy, 3:4 guarantee, 1 max', () => {
@@ -100,5 +101,53 @@ describe('variable attack speeds should not merge states from different timeline
       .toBeCloseTo(4.99e-05);
     expect(result.get(83))
       .toBeCloseTo(2.64e-05);
+  });
+
+  test('executioner does not instantly kill through ranged damage reduction', () => {
+    const monster = getTestMonster('Abyssal demon', 'Standard', {
+      skills: {
+        hp: 10,
+      },
+      inputs: {
+        monsterCurrentHp: 2,
+      },
+    });
+    const player = getTestPlayer(monster, {
+      leagues: {
+        six: {
+          executionerEnabled: true,
+        },
+      },
+    });
+
+    const calc = new PlayerVsNPCCalc(player, monster);
+    calc.getDistribution = () => new AttackDistribution([new HitDistribution([
+      new WeightedHit(1.0, [Hitsplat.INACCURATE]),
+    ])]);
+    calc.applyNpcTransforms = () => divisionTransformer(2, 1);
+    const result = calc.getTtkDistribution();
+
+    expect(result.get(calc.getAttackSpeed())).toBeUndefined();
+    expect(result.size).toBeGreaterThan(0);
+  });
+
+  test('executioner has no effect against yama', () => {
+    const monster = getTestMonster('Yama', '', {
+      id: YAMA_IDS[0],
+    });
+    const basePlayer = getTestPlayer(monster);
+    const executionerPlayer = getTestPlayer(monster, {
+      leagues: {
+        six: {
+          executionerEnabled: true,
+        },
+      },
+    });
+
+    const baseCalc = new PlayerVsNPCCalc(basePlayer, monster);
+    const executionerCalc = new PlayerVsNPCCalc(executionerPlayer, monster);
+
+    expect(executionerCalc.getTtk()).toBeCloseTo(baseCalc.getTtk());
+    expect(executionerCalc.getExecutionerDps()).toBeUndefined();
   });
 });

--- a/src/tests/utils/TestUtils.ts
+++ b/src/tests/utils/TestUtils.ts
@@ -125,6 +125,8 @@ export function calculatePlayerVsNpc(monster: Monster, player: Player, opts?: Ca
     maxAttackRoll: calc.getMaxAttackRoll(),
     accuracy: calc.getHitChance(),
     dps: calc.getDps(),
+    executionerDps: calc.getExecutionerDps(),
+    ttk: calc.getTtk(),
     details: calc.details,
     dist: calc.getDistribution(),
   };

--- a/src/types/Player.ts
+++ b/src/types/Player.ts
@@ -85,6 +85,8 @@ export interface LeaguesState {
 
   effects: { [k in LeaguesEffect]?: number };
 
+  executionerEnabled: boolean;
+
   distanceToEnemy: number;
 
   enemyPrayers: {

--- a/src/types/State.ts
+++ b/src/types/State.ts
@@ -60,6 +60,7 @@ export interface PlayerVsNPCCalculatedLoadout extends CalculatedLoadout {
   maxAttackRoll?: number,
   accuracy?: number,
   dps?: number,
+  executionerDps?: number,
   ttk?: number,
   hitDist?: ChartEntry[],
   ttkDist?: Map<number, number>,

--- a/src/worker/worker.ts
+++ b/src/worker/worker.ts
@@ -39,6 +39,7 @@ const computePvMValues: Handler<WorkerRequestType.COMPUTE_BASIC> = async (data) 
       maxAttackRoll: calc.getMaxAttackRoll(),
       accuracy: calc.getDisplayHitChance(),
       dps: calc.getDps(),
+      executionerDps: calc.getExecutionerDps(),
       ttk: calc.getTtk(),
       hitDist: calc.getDistribution().asHistogram(calcOpts.hitDistHideMisses),
       details: calc.details,


### PR DESCRIPTION
- Added executioner to dps calc: in parantheses (extra dps with 20% execution)
- takes previous weapon tick cycle into account
- changes TTK based on expected (approximately) 20% hp ttk.

Note: refactored distIsCurrentHpDependent

### Executioner: off
<img width="1036" height="843" alt="image" src="https://github.com/user-attachments/assets/6d951a36-4993-4f02-a442-6dcdb41afc32" />

### Executioner: on

<img width="1039" height="725" alt="image" src="https://github.com/user-attachments/assets/324cb2b8-8fca-48ff-a34b-4b0548ae0561" />
