### PR TITLE
Add stat row for leagues thorns/recoil damage

### DIFF
--- a/src/app/components/player/DemonicPactsLeague.tsx
+++ b/src/app/components/player/DemonicPactsLeague.tsx
@@ -137,9 +137,6 @@ const DemonicPactsLeague: React.FC = observer(() => {
     if (leaguesEffects.talent_max_hit_style_swap) {
       unimplemented.push('Style Swap Damage Bonus');
     }
-    if (leaguesEffects.talent_thorns_damage || leaguesEffects.talent_shield_reflect) {
-      unimplemented.push('Thorns');
-    }
     if (leaguesEffects.talent_overheal_consumption_boost || leaguesEffects.talent_fire_hp_consume_for_damage) {
       unimplemented.push('Overheal Consumption Effects');
     }

--- a/src/app/components/player/DemonicPactsLeague.tsx
+++ b/src/app/components/player/DemonicPactsLeague.tsx
@@ -274,7 +274,7 @@ const DemonicPactsLeague: React.FC = observer(() => {
               <NumberInput
                 aria-labelledby="expectedNpcHitLabel"
                 className="form-control w-12 text-centerl"
-                id="regenerateMagicLevelBoost"
+                id="expectedNpcHit"
                 min={0}
                 title="Expected npc damage"
                 value={store.player.leagues.six.expectedNpcHit}

--- a/src/app/components/player/DemonicPactsLeague.tsx
+++ b/src/app/components/player/DemonicPactsLeague.tsx
@@ -146,6 +146,13 @@ const DemonicPactsLeague: React.FC = observer(() => {
     return unimplemented;
   }).get();
 
+  const hasAnyRecoilTalents = computed(() => {
+    const leaguesEffects = store.player.leagues.six.effects;
+    return leaguesEffects.talent_defence_recoil_scaling
+      || leaguesEffects.talent_shield_reflect
+      || leaguesEffects.talent_thorns_damage;
+  });
+
   return (
     <>
       {(unimplementedPacts.length > 0) && (
@@ -263,6 +270,36 @@ const DemonicPactsLeague: React.FC = observer(() => {
             </span>
           </div>
         </ShowIfLeagueEffectEnabled>
+
+        {
+          hasAnyRecoilTalents && (
+            <div className="flex items-center gap-2 mt-2">
+              <NumberInput
+                aria-labelledby="expectedNpcHitLabel"
+                className="form-control w-12 text-centerl"
+                id="regenerateMagicLevelBoost"
+                min={0}
+                title="Expected npc damage"
+                value={store.player.leagues.six.expectedNpcHit}
+                onChange={(v) => {
+                  store.updatePlayer({ leagues: { six: { expectedNpcHit: v } } });
+                }}
+              />
+
+              <span id="expectedNpcHitLabel" className="ml-1 text-sm select-none">
+                Expected NPC damage
+                {' '}
+                <span
+                  className="align-super underline decoration-dotted cursor-help text-xs text-gray-300"
+                  data-tooltip-id="tooltip"
+                  data-tooltip-content="Expected incoming damage from npc, used to calculate recoil damage."
+                >
+                  ?
+                </span>
+              </span>
+            </div>
+          )
+        }
 
         <ShowIfLeagueEffectEnabled leaguesEffect="talent_free_random_weapon_attack_chance">
           <BlindbagSelector />

--- a/src/app/components/results/PlayerVsNPCResultsTable.tsx
+++ b/src/app/components/results/PlayerVsNPCResultsTable.tsx
@@ -151,6 +151,16 @@ const PlayerVsNPCResultsTable: React.FC = observer(() => {
         <ResultRow calcKey="accuracy" title="How accurate you are against the monster" hasResults={hasResults}>
           Accuracy
         </ResultRow>
+        {showLeaguesRows && (
+          <>
+            <ResultRowHeader>
+              Leagues
+            </ResultRowHeader>
+            <ResultRow calcKey="recoilDamage" title="The expected recoil damage dealt back to mob" hasResults={hasResults}>
+              Recoil damage
+            </ResultRow>
+          </>
+        )}
         {!resultsExpanded && (
           <ResultRow calcKey="specExpected" title="The expected hit that the special attack will deal to the monster per use, including misses" hasResults={hasResults} collapseSpecs={resultsExpanded}>
             Spec expected hit
@@ -185,16 +195,6 @@ const PlayerVsNPCResultsTable: React.FC = observer(() => {
             <ResultRow calcKey="specExpected" title="The expected hit that the special attack will deal to the monster per use, including misses" hasResults={hasResults} collapseSpecs={resultsExpanded}>
               Expected hit
             </ResultRow>
-            {showLeaguesRows && (
-              <>
-                <ResultRowHeader>
-                  Leagues
-                </ResultRowHeader>
-                <ResultRow calcKey="recoilDamage" title="The expected recoil damage dealt back to mob" hasResults={hasResults}>
-                  Recoil damage
-                </ResultRow>
-              </>
-            )}
           </>
         )}
       </tbody>

--- a/src/app/components/results/PlayerVsNPCResultsTable.tsx
+++ b/src/app/components/results/PlayerVsNPCResultsTable.tsx
@@ -112,7 +112,7 @@ const PlayerVsNPCResultsTable: React.FC = observer(() => {
 
   const loadouts = toJS(calc.loadouts);
   const hasResults = useMemo(() => some(loadouts, (l) => some(Object.entries(l), ([, v]) => isDefined(v))), [loadouts]);
-  const showLeaguesRows = useMemo(() => some(loadouts, (l) => l.thornsDamage !== undefined), [loadouts]);
+  const showLeaguesRows = useMemo(() => some(loadouts, (l) => l.recoilDamage !== undefined), [loadouts]);
 
   return (
     <table>
@@ -190,11 +190,8 @@ const PlayerVsNPCResultsTable: React.FC = observer(() => {
                 <ResultRowHeader>
                   Leagues
                 </ResultRowHeader>
-                <ResultRow calcKey="thornsDamage" title="The expected melee damage dealt to mob on hit" hasResults={hasResults}>
-                  Thorns
-                </ResultRow>
-                <ResultRow calcKey="reflectChance" title="The expected chance to reflect all damage taken back to mob" hasResults={hasResults}>
-                  Reflect chance
+                <ResultRow calcKey="recoilDamage" title="The expected recoil damage dealt back to mob" hasResults={hasResults}>
+                  Recoil damage
                 </ResultRow>
               </>
             )}

--- a/src/app/components/results/PlayerVsNPCResultsTable.tsx
+++ b/src/app/components/results/PlayerVsNPCResultsTable.tsx
@@ -24,7 +24,6 @@ const calcKeyToString = (value: number, calcKey: keyof PlayerVsNPCCalculatedLoad
   switch (calcKey) {
     case 'accuracy':
     case 'specAccuracy':
-    case 'reflectChance':
       return `${(value * 100).toFixed(ACCURACY_PRECISION)}%`;
     case 'dps':
     case 'specMomentDps':
@@ -33,6 +32,7 @@ const calcKeyToString = (value: number, calcKey: keyof PlayerVsNPCCalculatedLoad
       return value.toPrecision(DPS_PRECISION);
     case 'expectedHit':
     case 'specExpected':
+    case 'recoilDamage':
       return value.toFixed(EXPECTED_HIT_PRECISION);
     case 'ttk':
       return value === 0

--- a/src/app/components/results/PlayerVsNPCResultsTable.tsx
+++ b/src/app/components/results/PlayerVsNPCResultsTable.tsx
@@ -112,7 +112,7 @@ const PlayerVsNPCResultsTable: React.FC = observer(() => {
 
   const loadouts = toJS(calc.loadouts);
   const hasResults = useMemo(() => some(loadouts, (l) => some(Object.entries(l), ([, v]) => isDefined(v))), [loadouts]);
-  const showLeaguesRows = useMemo(() => some(loadouts, (l) => l.recoilDamage !== undefined), [loadouts]);
+  const showRecoilRow = useMemo(() => some(loadouts, (l) => l.recoilDamage !== undefined), [loadouts]);
 
   return (
     <table>
@@ -151,15 +151,10 @@ const PlayerVsNPCResultsTable: React.FC = observer(() => {
         <ResultRow calcKey="accuracy" title="How accurate you are against the monster" hasResults={hasResults}>
           Accuracy
         </ResultRow>
-        {showLeaguesRows && (
-          <>
-            <ResultRowHeader>
-              Leagues
-            </ResultRowHeader>
-            <ResultRow calcKey="recoilDamage" title="The expected recoil damage dealt back to mob" hasResults={hasResults}>
-              Recoil damage
-            </ResultRow>
-          </>
+        {showRecoilRow && (
+          <ResultRow calcKey="recoilDamage" title="The expected recoil damage dealt back to mob" hasResults={hasResults}>
+            Recoil damage
+          </ResultRow>
         )}
         {!resultsExpanded && (
           <ResultRow calcKey="specExpected" title="The expected hit that the special attack will deal to the monster per use, including misses" hasResults={hasResults} collapseSpecs={resultsExpanded}>

--- a/src/app/components/results/PlayerVsNPCResultsTable.tsx
+++ b/src/app/components/results/PlayerVsNPCResultsTable.tsx
@@ -24,6 +24,7 @@ const calcKeyToString = (value: number, calcKey: keyof PlayerVsNPCCalculatedLoad
   switch (calcKey) {
     case 'accuracy':
     case 'specAccuracy':
+    case 'reflectChance':
       return `${(value * 100).toFixed(ACCURACY_PRECISION)}%`;
     case 'dps':
     case 'specMomentDps':
@@ -189,8 +190,11 @@ const PlayerVsNPCResultsTable: React.FC = observer(() => {
                 <ResultRowHeader>
                   Leagues
                 </ResultRowHeader>
-                <ResultRow calcKey="thornsDamage" title="" hasResults={hasResults}>
+                <ResultRow calcKey="thornsDamage" title="The expected melee damage dealt to mob on hit" hasResults={hasResults}>
                   Thorns
+                </ResultRow>
+                <ResultRow calcKey="reflectChance" title="The expected chance to reflect all damage taken back to mob" hasResults={hasResults}>
+                  Reflect chance
                 </ResultRow>
               </>
             )}

--- a/src/app/components/results/PlayerVsNPCResultsTable.tsx
+++ b/src/app/components/results/PlayerVsNPCResultsTable.tsx
@@ -111,6 +111,7 @@ const PlayerVsNPCResultsTable: React.FC = observer(() => {
 
   const loadouts = toJS(calc.loadouts);
   const hasResults = useMemo(() => some(loadouts, (l) => some(Object.entries(l), ([, v]) => isDefined(v))), [loadouts]);
+  const showLeaguesRows = useMemo(() => some(loadouts, (l) => l.thornsDamage !== undefined), [loadouts]);
 
   return (
     <table>
@@ -183,6 +184,16 @@ const PlayerVsNPCResultsTable: React.FC = observer(() => {
             <ResultRow calcKey="specExpected" title="The expected hit that the special attack will deal to the monster per use, including misses" hasResults={hasResults} collapseSpecs={resultsExpanded}>
               Expected hit
             </ResultRow>
+            {showLeaguesRows && (
+              <>
+                <ResultRowHeader>
+                  Leagues
+                </ResultRowHeader>
+                <ResultRow calcKey="thornsDamage" title="" hasResults={hasResults}>
+                  Thorns
+                </ResultRow>
+              </>
+            )}
           </>
         )}
       </tbody>

--- a/src/lib/CalcDetails.ts
+++ b/src/lib/CalcDetails.ts
@@ -99,6 +99,7 @@ export enum DetailKey {
   DIST_FINAL = 'Dist final',
   DIST_LEAGUES_BLINDBAG = 'Dist leagues blindbag',
   DIST_LEAGUES_BLINDBAG_RECURSIVE = 'Dist leagues blindbag recursive',
+  DIST_RECOIL = 'Dist recoil',
   DOT_EXPECTED = 'Damage over time expected',
   DOT_MAX = 'Damage over time max',
   GUARDIANS_DMG_BONUS = 'Guardians hit multiplier',

--- a/src/lib/Equipment.ts
+++ b/src/lib/Equipment.ts
@@ -587,3 +587,30 @@ export const CORRUPTED_GAUNTLET_EQUIPMENT_IDS = [
   23856, // Corrupted bow (attuned)
   23857, // Corrupted bow (perfected)
 ];
+
+// List of shields that don't contain the word "shield".
+// https://oldschool.runescape.wiki/w/Shields#Other
+const otherShields = [
+  'Malediction ward',
+  'Odium ward',
+  'Toktz-ket-xil',
+  'Twisted buckler',
+  'Dragonfire ward',
+];
+
+export const isHoldingShield = (inputEq: PlayerEquipment) => {
+  if (inputEq.shield) {
+    // Canonical item name less likely to have weird exceptions.
+    const name = getCanonicalItem(inputEq.shield).name;
+    if (name.toLowerCase().indexOf('shield') > 0) {
+      return true;
+    }
+
+    if (otherShields.indexOf(name) > 0) {
+      return true;
+    }
+  } else if (inputEq.weapon?.name === "Dinh's bulwark") {
+    return true;
+  }
+  return false;
+};

--- a/src/lib/Equipment.ts
+++ b/src/lib/Equipment.ts
@@ -596,6 +596,8 @@ const otherShields = [
   'Toktz-ket-xil',
   'Twisted buckler',
   'Dragonfire ward',
+  "Elidinis' ward",
+  "Elidinis' ward (f)",
 ];
 
 export const isHoldingShield = (inputEq: PlayerEquipment) => {
@@ -609,7 +611,7 @@ export const isHoldingShield = (inputEq: PlayerEquipment) => {
     if (otherShields.indexOf(name) > 0) {
       return true;
     }
-  } else if (inputEq.weapon?.name === "Dinh's bulwark") {
+  } else if (inputEq.weapon?.category === EquipmentCategory.BULWARK) {
     return true;
   }
   return false;

--- a/src/lib/PlayerVsNPCCalc.ts
+++ b/src/lib/PlayerVsNPCCalc.ts
@@ -2524,37 +2524,57 @@ export default class PlayerVsNPCCalc extends BaseCalc {
     return ttks;
   }
 
-  public getThornsDamage(): number | undefined {
-    const leaguesEffects = this.player.leagues.six.effects;
-    let damage = leaguesEffects.talent_thorns_damage;
-    if (!damage || !isHoldingShield(this.player.equipment)) {
-      return undefined;
-    }
+  public getRecoilDamage(): number | undefined {
+    const dist = new AttackDistribution([]);
 
-    if (leaguesEffects.talent_defence_recoil_scaling) {
+    // This applies to all forms of recoil.
+    let recoilDamageBonus = 0;
+    if (this.player.leagues.six.effects.talent_defence_recoil_scaling) {
       const defensiveBonuses = this.player.defensive.crush
-        + this.player.defensive.slash
-        + this.player.defensive.stab
-        + this.player.defensive.ranged
-        + this.player.defensive.magic;
-      damage += Math.trunc(defensiveBonuses / 100);
+          + this.player.defensive.slash
+          + this.player.defensive.stab
+          + this.player.defensive.ranged
+          + this.player.defensive.magic;
+      recoilDamageBonus = Math.trunc(defensiveBonuses / 100);
+      this.track('Recoil damage bonus', recoilDamageBonus);
     }
 
-    if (leaguesEffects.talent_thorns_double_hit) {
-      damage += Math.trunc(damage / 2);
-    }
-
-    return damage;
-  }
-
-  public getReflectChance(): number | undefined {
     const leaguesEffects = this.player.leagues.six.effects;
-    if (!leaguesEffects.talent_shield_reflect || !isHoldingShield(this.player.equipment)) {
-      return undefined;
+    const hasShield = isHoldingShield(this.player.equipment);
+    if (leaguesEffects.talent_thorns_damage && hasShield) {
+      const thornsDamage = leaguesEffects.talent_thorns_damage + recoilDamageBonus;
+      const hitSplats = [new Hitsplat(thornsDamage)];
+      if (leaguesEffects.talent_thorns_double_hit) {
+        hitSplats.push(new Hitsplat(Math.trunc(thornsDamage / 2)));
+      }
+      dist.addDist(HitDistribution.single(1, hitSplats));
+      this.trackDist('Thorns dist', dist);
     }
 
-    const defenceLevel = this.player.skills.def + this.player.boosts.def;
-    return defenceLevel * 0.001;
+    // All other recoil requires atleast some damage be dealt.
+    const incomingDamage = this.player.leagues.six.expectedNpcHit;
+    if (incomingDamage > 0) {
+      if (leaguesEffects.talent_shield_reflect && hasShield) {
+        const defenceLevel = this.player.skills.def + this.player.boosts.def;
+        const reflectChance = defenceLevel * 0.001;
+        const reflectDamage = incomingDamage + recoilDamageBonus;
+
+        dist.addDist(HitDistribution.single(reflectChance, [new Hitsplat(reflectDamage)]));
+      }
+
+      if (this.wearing('Ring of recoil') || this.wearing('Ring of suffering (i)') || this.wearing('Ring of suffering')) {
+        const recoilDamage = 1 + Math.trunc(incomingDamage / 10) + recoilDamageBonus;
+        dist.addDist(HitDistribution.single(1, [new Hitsplat(recoilDamage)]));
+      }
+
+      if (this.wearing('Echo boots') && this.player.leagues.six.distanceToEnemy === 1) {
+        dist.addDist(HitDistribution.single(1, [new Hitsplat(1 + recoilDamageBonus)]));
+      }
+    }
+
+    this.trackDist(DetailKey.DIST_RECOIL, dist);
+
+    return dist.getExpectedDamage();
   }
 
   distAtHp(baseDist: DelayedHit[], hp: number): DelayedHit[] {

--- a/src/lib/PlayerVsNPCCalc.ts
+++ b/src/lib/PlayerVsNPCCalc.ts
@@ -2527,7 +2527,7 @@ export default class PlayerVsNPCCalc extends BaseCalc {
   public getRecoilDamage(): number | undefined {
     const dist = new AttackDistribution([]);
 
-    // This applies to all forms of recoil.
+    // Description says this applies to all forms of thorns / recoil.
     let recoilDamageBonus = 0;
     if (this.player.leagues.six.effects.talent_defence_recoil_scaling) {
       const defensiveBonuses = this.player.defensive.crush
@@ -2536,7 +2536,6 @@ export default class PlayerVsNPCCalc extends BaseCalc {
           + this.player.defensive.ranged
           + this.player.defensive.magic;
       recoilDamageBonus = Math.trunc(defensiveBonuses / 100);
-      this.track('Recoil damage bonus', recoilDamageBonus);
     }
 
     const leaguesEffects = this.player.leagues.six.effects;
@@ -2548,7 +2547,6 @@ export default class PlayerVsNPCCalc extends BaseCalc {
         hitSplats.push(new Hitsplat(Math.trunc(thornsDamage / 2)));
       }
       dist.addDist(HitDistribution.single(1, hitSplats));
-      this.trackDist('Thorns dist', dist);
     }
 
     // All other recoil requires atleast some damage be dealt.
@@ -2573,7 +2571,6 @@ export default class PlayerVsNPCCalc extends BaseCalc {
     }
 
     this.trackDist(DetailKey.DIST_RECOIL, dist);
-
     return dist.getExpectedDamage();
   }
 

--- a/src/lib/PlayerVsNPCCalc.ts
+++ b/src/lib/PlayerVsNPCCalc.ts
@@ -2571,6 +2571,9 @@ export default class PlayerVsNPCCalc extends BaseCalc {
     }
 
     this.trackDist(DetailKey.DIST_RECOIL, dist);
+    if (dist.dists.length === 0) {
+      return undefined;
+    }
     return dist.getExpectedDamage();
   }
 

--- a/src/lib/PlayerVsNPCCalc.ts
+++ b/src/lib/PlayerVsNPCCalc.ts
@@ -2523,6 +2523,32 @@ export default class PlayerVsNPCCalc extends BaseCalc {
     return ttks;
   }
 
+  public getThornsDamage(): number | undefined {
+    const leaguesEffects = this.player.leagues.six.effects;
+    let damage = leaguesEffects.talent_thorns_damage;
+    if (!damage) {
+      // If primary Thorns talent isn't chosen do the other ones work?
+      return undefined;
+    }
+
+    const hasShield = isShield();
+
+    if (leaguesEffects.talent_defence_recoil_scaling) {
+      const defensiveBonuses = this.player.defensive.crush
+        + this.player.defensive.slash
+        + this.player.defensive.stab
+        + this.player.defensive.ranged
+        + this.player.defensive.magic;
+      damage += Math.trunc(defensiveBonuses / 100);
+    }
+
+    if (leaguesEffects.talent_thorns_double_hit) {
+      damage += Math.trunc(damage / 2);
+    }
+
+    return damage;
+  }
+
   distAtHp(baseDist: DelayedHit[], hp: number): DelayedHit[] {
     if (this.opts.disableMonsterScaling) {
       return baseDist;

--- a/src/lib/PlayerVsNPCCalc.ts
+++ b/src/lib/PlayerVsNPCCalc.ts
@@ -71,6 +71,7 @@ import {
   calculateAttackSpeed,
   calculateEquipmentBonusesFromGear,
   getCanonicalItem,
+  isHoldingShield,
   WEAPON_SPEC_COSTS,
 } from '@/lib/Equipment';
 import BaseCalc, { CalcOpts, InternalOpts } from '@/lib/BaseCalc';
@@ -2526,12 +2527,9 @@ export default class PlayerVsNPCCalc extends BaseCalc {
   public getThornsDamage(): number | undefined {
     const leaguesEffects = this.player.leagues.six.effects;
     let damage = leaguesEffects.talent_thorns_damage;
-    if (!damage) {
-      // If primary Thorns talent isn't chosen do the other ones work?
+    if (!damage || !isHoldingShield(this.player.equipment)) {
       return undefined;
     }
-
-    const hasShield = isShield();
 
     if (leaguesEffects.talent_defence_recoil_scaling) {
       const defensiveBonuses = this.player.defensive.crush

--- a/src/lib/PlayerVsNPCCalc.ts
+++ b/src/lib/PlayerVsNPCCalc.ts
@@ -2547,6 +2547,16 @@ export default class PlayerVsNPCCalc extends BaseCalc {
     return damage;
   }
 
+  public getReflectChance(): number | undefined {
+    const leaguesEffects = this.player.leagues.six.effects;
+    if (!leaguesEffects.talent_shield_reflect || !isHoldingShield(this.player.equipment)) {
+      return undefined;
+    }
+
+    const defenceLevel = this.player.skills.def + this.player.boosts.def;
+    return defenceLevel * 0.001;
+  }
+
   distAtHp(baseDist: DelayedHit[], hp: number): DelayedHit[] {
     if (this.opts.disableMonsterScaling) {
       return baseDist;

--- a/src/state.tsx
+++ b/src/state.tsx
@@ -151,6 +151,7 @@ export const generateEmptyPlayer = (name?: string): Player => ({
       },
       blindbagWeapons: [],
       regenerateMagicBonus: 0,
+      expectedNpcHit: 0,
       cullingSpree: false,
     },
   },

--- a/src/types/Player.ts
+++ b/src/types/Player.ts
@@ -98,6 +98,8 @@ export interface LeaguesState {
   regenerateMagicBonus: number;
 
   cullingSpree: boolean;
+
+  expectedNpcHit: number;
 }
 
 export interface Player extends EquipmentStats {

--- a/src/types/State.ts
+++ b/src/types/State.ts
@@ -70,6 +70,8 @@ export interface PlayerVsNPCCalculatedLoadout extends CalculatedLoadout {
   specMomentDps?: number,
   specFullDps?: number,
   specHitDist?: ChartEntry[],
+
+  thornsDamage?: number;
 }
 
 // NPC vs Player metrics

--- a/src/types/State.ts
+++ b/src/types/State.ts
@@ -72,7 +72,6 @@ export interface PlayerVsNPCCalculatedLoadout extends CalculatedLoadout {
   specHitDist?: ChartEntry[],
 
   recoilDamage?: number;
-  reflectChance?: number;
 }
 
 // NPC vs Player metrics

--- a/src/types/State.ts
+++ b/src/types/State.ts
@@ -72,6 +72,7 @@ export interface PlayerVsNPCCalculatedLoadout extends CalculatedLoadout {
   specHitDist?: ChartEntry[],
 
   thornsDamage?: number;
+  reflectChance?: number;
 }
 
 // NPC vs Player metrics

--- a/src/types/State.ts
+++ b/src/types/State.ts
@@ -71,7 +71,7 @@ export interface PlayerVsNPCCalculatedLoadout extends CalculatedLoadout {
   specFullDps?: number,
   specHitDist?: ChartEntry[],
 
-  thornsDamage?: number;
+  recoilDamage?: number;
   reflectChance?: number;
 }
 

--- a/src/worker/worker.ts
+++ b/src/worker/worker.ts
@@ -41,6 +41,9 @@ const computePvMValues: Handler<WorkerRequestType.COMPUTE_BASIC> = async (data) 
       dps: calc.getDps(),
       ttk: calc.getTtk(),
       hitDist: calc.getDistribution().asHistogram(calcOpts.hitDistHideMisses),
+
+      recoilDamage: calc.getRecoilDamage(),
+
       details: calc.details,
       userIssues: calc.userIssues,
 
@@ -51,9 +54,6 @@ const computePvMValues: Handler<WorkerRequestType.COMPUTE_BASIC> = async (data) 
       specFullDps: specCalc?.getSpecDps(),
       specHitDist: specCalc?.getDistribution().asHistogram(calcOpts.hitDistHideMisses),
       specDetails: specCalc?.details,
-
-      thornsDamage: calc.getThornsDamage(),
-      reflectChance: calc.getReflectChance(),
     });
 
     const end = self.performance.now();

--- a/src/worker/worker.ts
+++ b/src/worker/worker.ts
@@ -53,6 +53,7 @@ const computePvMValues: Handler<WorkerRequestType.COMPUTE_BASIC> = async (data) 
       specDetails: specCalc?.details,
 
       thornsDamage: calc.getThornsDamage(),
+      reflectChance: calc.getReflectChance(),
     });
 
     const end = self.performance.now();

--- a/src/worker/worker.ts
+++ b/src/worker/worker.ts
@@ -51,6 +51,8 @@ const computePvMValues: Handler<WorkerRequestType.COMPUTE_BASIC> = async (data) 
       specFullDps: specCalc?.getSpecDps(),
       specHitDist: specCalc?.getDistribution().asHistogram(calcOpts.hitDistHideMisses),
       specDetails: specCalc?.details,
+
+      thornsDamage: calc.getThornsDamage(),
     });
 
     const end = self.performance.now();


### PR DESCRIPTION
Adds a new stat row to help calculate expected recoil damage with leagues talents. Row is only shown if there is some recoil damage is non-zero.
For thorns damage calculation is trivial as it does not vary with damage / accuracy. For rest of damage we allow user to input an expected damage, this ends up being more useful than trying to use the limited NPC vs Player damage calc.