### PR TITLE
Miscellanious Fixes

### DIFF
--- a/src/lib/BaseCalc.ts
+++ b/src/lib/BaseCalc.ts
@@ -780,7 +780,7 @@ export default class BaseCalc {
       (spellName === 'Iban Blast' && !this.wearing(['Iban\'s staff', 'Iban\'s staff (u)']))
       || (spellName === 'Saradomin Strike' && !this.wearing(['Saradomin staff', 'Staff of light']))
       || (spellName === 'Claws of Guthix' && !this.wearing(['Guthix staff', 'Void knight mace', 'Staff of balance']))
-      || (spellName === 'Flames of Zamarok' && !this.wearing(['Zamorak staff', 'Staff of the dead', 'Toxic staff of the dead', 'Thammaron\'s sceptre (a)', 'Accursed sceptre (a)']))
+      || (spellName === 'Flames of Zamorak' && !this.wearing(['Zamorak staff', 'Staff of the dead', 'Toxic staff of the dead', 'Thammaron\'s sceptre (a)', 'Accursed sceptre (a)']))
       || (spellName === 'Magic Dart' && !this.wearing(['Slayer\'s staff', 'Slayer\'s staff (e)', 'Staff of the dead', 'Toxic staff of the dead', 'Staff of light', 'Staff of balance']))
     ) {
       this.player = {

--- a/src/lib/Equipment.ts
+++ b/src/lib/Equipment.ts
@@ -195,16 +195,25 @@ export const ammoApplicability = (weaponId?: number, ammoId?: number): AmmoAppli
   return AmmoApplicability.INVALID;
 };
 
+// Prebuilt reverse lookup (variant item id -> canonical/base item id), built once at module load.
+const variantToCanonicalId: { [variantId: number]: number } = (() => {
+  const map: { [variantId: number]: number } = {};
+  for (const [k, v] of Object.entries(equipmentAliases)) {
+    const canonicalId = parseInt(k);
+    for (const variant of v) {
+      if (!(variant in map)) {
+        map[variant] = canonicalId;
+      }
+    }
+  }
+  return map;
+})();
+
 /**
  * Returns the canonical (base) item ID for a given item ID. This is useful if there are variants of each item.
  * @param itemId
  */
-export const getCanonicalItemId = (itemId: number): number => {
-  for (const [k, v] of Object.entries(equipmentAliases)) {
-    if (v.includes(itemId)) return parseInt(k);
-  }
-  return itemId;
-};
+export const getCanonicalItemId = (itemId: number): number => variantToCanonicalId[itemId] ?? itemId;
 
 export const getCanonicalItem = (equipmentPiece: EquipmentPiece): EquipmentPiece => {
   const canonicalId = getCanonicalItemId(equipmentPiece.id);
@@ -436,7 +445,7 @@ export const calculateEquipmentBonusesFromGear = (player: Player, monster: Monst
   const dizanasQuiverCharged = cape?.name === "Dizana's max cape"
     || cape?.name === "Blessed dizana's quiver"
     || (cape?.name === "Dizana's quiver" && cape?.version === 'Charged');
-  if (dizanasQuiverCharged && ammoApplicability(player.equipment.weapon?.id, player.equipment.ammo?.id) === AmmoApplicability.INCLUDED) {
+  if (dizanasQuiverCharged && ammoApplicability(playerEquipment.weapon?.id, playerEquipment.ammo?.id) === AmmoApplicability.INCLUDED) {
     totals.offensive.ranged += 10;
     totals.bonuses.ranged_str += 1;
   }

--- a/src/lib/HitDist.ts
+++ b/src/lib/HitDist.ts
@@ -261,7 +261,7 @@ export class HitDistribution {
     }
 
     for (const [key, prob] of acc.entries()) {
-      const delay = (key & 0x8F000000) >> 24;
+      const delay = (key & 0xFF000000) >>> 24;
       const dmg = key & 0xFFFFFF;
       d.push([new WeightedHit(prob, [new Hitsplat(dmg, true)]), delay]);
     }

--- a/src/lib/NPCVsPlayerCalc.ts
+++ b/src/lib/NPCVsPlayerCalc.ts
@@ -226,7 +226,7 @@ export default class NPCVsPlayerCalc extends BaseCalc {
 
     // Some monsters have a reduced max hit under specific conditions
     if (name === 'Aberrant spectre' && (this.wearing('Nose peg') || this.isWearingSlayerHelmet())) maxHit = 8;
-    if (name === 'Dust devil' && (this.wearing('Face mask') || this.isWearingSlayerHelmet())) maxHit = 8;
+    if (name === 'Dust devil' && (this.wearing('Facemask') || this.isWearingSlayerHelmet())) maxHit = 8;
     if (name === 'Banshee' && (this.wearing('Earmuffs') || this.isWearingSlayerHelmet())) maxHit = 2;
     if (name === 'Wall beast' && (this.wearing('Spiny helmet') || this.isWearingSlayerHelmet())) maxHit = 4;
     if (name === 'Sourhog' && (this.wearing('Reinforced goggles') || this.isWearingSlayerHelmet())) maxHit = 6;
@@ -254,6 +254,9 @@ export default class NPCVsPlayerCalc extends BaseCalc {
    * Returns the expected damage per tick, based on the NPC's attack speed.
    */
   public getDpt() {
+    if (this.monster.speed <= 0) {
+      return 0;
+    }
     return this.getDistribution().getExpectedDamage() / this.monster.speed;
   }
 

--- a/src/lib/PlayerVsNPCCalc.ts
+++ b/src/lib/PlayerVsNPCCalc.ts
@@ -432,7 +432,7 @@ export default class PlayerVsNPCCalc extends BaseCalc {
     if (this.isRevWeaponBuffApplicable()) {
       maxHit = this.trackFactor(DetailKey.MAX_HIT_REV_WEAPON, maxHit, [3, 2]);
     }
-    if (this.wearing(['Silverlight', 'Darklight', 'Silverlight (dyed)']) && mattrs.includes(MonsterAttribute.DEMON)) {
+    if (this.wearing(['Silverlight', 'Darklight']) && mattrs.includes(MonsterAttribute.DEMON)) {
       maxHit = this.trackAddFactor(DetailKey.MAX_HIT_DEMONBANE, maxHit, this.demonbaneFactor(60));
     }
     if (this.wearing('Infernal tecpatl') && mattrs.includes(MonsterAttribute.DEMON)) {
@@ -2039,7 +2039,7 @@ export default class PlayerVsNPCCalc extends BaseCalc {
         relevantEffects.push([divisionTransformer(2)]);
       } else if (this.player.style.type !== 'ranged'
         || !this.player.equipment.ammo?.name.includes(' brutal')
-        || this.player.equipment.weapon?.name !== 'Comp ogre bow') {
+        || !this.isWearingOgreBow()) {
         relevantEffects.push([divisionTransformer(4)]);
       }
     }
@@ -2813,7 +2813,7 @@ export default class PlayerVsNPCCalc extends BaseCalc {
     const currentHp = this.player.skills.hp + this.player.boosts.hp;
 
     // intentionally not capping to maxHp here as it functions on overheal
-    const damageBonusPct = Math.trunc(20 * currentHp / maxHp);
+    const damageBonusPct = maxHp > 0 ? Math.trunc(20 * currentHp / maxHp) : 0;
     return multiplyTransformer(100 + damageBonusPct, 100);
   }
 }

--- a/src/lib/scaling/ChambersOfXeric.ts
+++ b/src/lib/scaling/ChambersOfXeric.ts
@@ -49,7 +49,7 @@ const getSkillMeta = (m: Monster): SkillMeta => {
   const baseDefensive = max(defensives, (k) => m.skills[k]) ?? 1;
 
   const baseHp = GUARDIAN_IDS.includes(m.id)
-    ? 151 + Math.trunc(m.inputs.partySumMiningLevel / m.inputs.partySize)
+    ? 151 + Math.trunc(m.inputs.partySumMiningLevel / Math.max(1, m.inputs.partySize))
     : m.skills.hp;
 
   return {

--- a/src/lib/scaling/TombsOfAmascut.ts
+++ b/src/lib/scaling/TombsOfAmascut.ts
@@ -19,7 +19,7 @@ const applyToaScaling = (m: Monster): Monster => {
 
   const pathLevel = Math.min(6, Math.max(0, inputs.toaPathLevel));
   if (TOMBS_OF_AMASCUT_PATH_MONSTER_IDS.includes(m.id) && pathLevel >= 1) {
-    const pathLevelFactor = 3 + 5 * inputs.toaPathLevel;
+    const pathLevelFactor = 3 + 5 * pathLevel;
     newHp = Math.trunc(newHp * (100 + pathLevelFactor) / 100);
   }
 

--- a/src/tests/calc/Zogres.test.ts
+++ b/src/tests/calc/Zogres.test.ts
@@ -67,6 +67,29 @@ describe('Zogre damage resistances', () => {
     expect(maxHit).toBe(19); // comp ogre bow only uses arrow str bonus
   });
 
+  test('Brutal arrows apply full damage with the regular Ogre bow', () => {
+    // Adamant/Rune brutal are Comp-ogre-bow-only; the regular Ogre bow fires up to Mithril brutal.
+    const withBow = (weaponName: string): Player => getTestPlayer(m, {
+      equipment: {
+        weapon: findEquipment(weaponName),
+        ammo: findEquipment('Mithril brutal'),
+      },
+      style: {
+        type: 'ranged',
+        stance: 'Rapid',
+      },
+    });
+
+    // The Comp ogre bow is the known-exempt baseline (full, unreduced damage).
+    const compMaxHit = calculatePlayerVsNpc(m, withBow('Comp ogre bow')).maxHit;
+    const ogreMaxHit = calculatePlayerVsNpc(m, withBow('Ogre bow')).maxHit;
+
+    // The regular Ogre bow firing brutal arrows must also bypass the 1/4 reduction
+    // (max hit does not depend on which ogre bow is used).
+    expect(ogreMaxHit).toBeGreaterThan(0);
+    expect(ogreMaxHit).toBe(compMaxHit);
+  });
+
   test('Brutal arrows do not skip damage reduction when not used', () => {
     const { maxHit } = calculatePlayerVsNpc(m, getTestPlayer(m, {
       equipment: {


### PR DESCRIPTION
Context for why I'm doing this - I'm working on a Kotlin port of the calculator for a Runelite Plugin that I want to attempt to maintain with this is as the upstream. Found these mostly minor issues while porting. All changes are output-preserving for valid loadouts: the full local suite is unchanged except +1 new passing test. 

Calculation issues:
- BaseCalc: 'Flames of Zamarok' -> 'Flames of Zamorak' so the spell-requires- weapon validation actually fires (was dead code due to the typo).
- PlayerVsNPCCalc: the regular Ogre bow firing brutal arrows now bypasses the Zogre/Skogre 1/4 damage reduction like the Comp ogre bow (use isWearingOgreBow instead of an exact 'Comp ogre bow' name check).
- NPCVsPlayerCalc: 'Face mask' -> 'Facemask' so the Dust devil reduced-max-hit (slayer item) branch is reachable.
- scaling/TombsOfAmascut: path-level HP scaling uses the clamped pathLevel, not the raw input (out-of-range path levels were unclamped).
- PlayerVsNPCCalc: drop dead 'Silverlight (dyed)' name (both variants are named 'Silverlight'). (Regular Runescape uses (dyed) variant)


Division By Zero Guards
- NPCVsPlayerCalc.getDpt: guard monster.speed <= 0 (e.g. Spinolyp 'Suspicious water' has speed 0 -> Infinity DPS/damage-taken).
- scaling/ChambersOfXeric: force the Guardian-HP partySize divisor to >= 1.
- PlayerVsNPCCalc.leaguesWaterHpBonus: guard skills.hp == 0
- HitDist.withProbabilisticDelays: fix the delay decode mask (0x8F000000 >> 24 -> 0xFF000000 >>> 24); was correct only for delays < 16.

Optimization:
- Equipment.getCanonicalItemId: replace the per-call full alias-map scan with a reverse lookup map built once at module load. This runs per equipped item on every calc.


Tests:
- Adds a regression test for the Ogre bow / Zogre fix.