### PR TITLE
Add XP/H stat to results table

### DIFF
--- a/cdn/json/spells.json
+++ b/cdn/json/spells.json
@@ -3,6 +3,7 @@
     "name": "Bind",
     "image": "Bind.png",
     "max_hit": 0,
+    "base_xp": 30,
     "spellbook": "standard",
     "element": null
   },
@@ -10,6 +11,7 @@
     "name": "Blood Barrage",
     "image": "Blood Barrage.png",
     "max_hit": 29,
+    "base_xp": 51,
     "spellbook": "ancient",
     "element": null
   },
@@ -17,6 +19,7 @@
     "name": "Blood Blitz",
     "image": "Blood Blitz.png",
     "max_hit": 25,
+    "base_xp": 45,
     "spellbook": "ancient",
     "element": null
   },
@@ -24,6 +27,7 @@
     "name": "Blood Burst",
     "image": "Blood Burst.png",
     "max_hit": 21,
+    "base_xp": 39,
     "spellbook": "ancient",
     "element": null
   },
@@ -31,6 +35,7 @@
     "name": "Blood Rush",
     "image": "Blood Rush.png",
     "max_hit": 15,
+    "base_xp": 33,
     "spellbook": "ancient",
     "element": null
   },
@@ -38,6 +43,7 @@
     "name": "Claws of Guthix",
     "image": "Claws of Guthix.png",
     "max_hit": 20,
+    "base_xp": 35,
     "spellbook": "standard",
     "element": null
   },
@@ -45,6 +51,7 @@
     "name": "Confuse",
     "image": "Confuse.png",
     "max_hit": 0,
+    "base_xp": 13,
     "spellbook": "standard",
     "element": null
   },
@@ -52,6 +59,7 @@
     "name": "Crumble Undead",
     "image": "Crumble Undead.png",
     "max_hit": 15,
+    "base_xp": 24.5,
     "spellbook": "standard",
     "element": null
   },
@@ -59,6 +67,7 @@
     "name": "Curse",
     "image": "Curse.png",
     "max_hit": 0,
+    "base_xp": 29,
     "spellbook": "standard",
     "element": null
   },
@@ -66,6 +75,7 @@
     "name": "Dark Demonbane",
     "image": "Dark Demonbane.png",
     "max_hit": 30,
+    "base_xp": 43.5,
     "spellbook": "arceuus",
     "element": null
   },
@@ -73,6 +83,7 @@
     "name": "Dark Lure",
     "image": "Dark Lure.png",
     "max_hit": 0,
+    "base_xp": 60,
     "spellbook": "arceuus",
     "element": null
   },
@@ -80,6 +91,7 @@
     "name": "Earth Blast",
     "image": "Earth Blast.png",
     "max_hit": 15,
+    "base_xp": 31.5,
     "spellbook": "standard",
     "element": "earth"
   },
@@ -87,6 +99,7 @@
     "name": "Earth Bolt",
     "image": "Earth Bolt.png",
     "max_hit": 11,
+    "base_xp": 19.5,
     "spellbook": "standard",
     "element": "earth"
   },
@@ -94,6 +107,7 @@
     "name": "Earth Strike",
     "image": "Earth Strike.png",
     "max_hit": 6,
+    "base_xp": 9.5,
     "spellbook": "standard",
     "element": "earth"
   },
@@ -101,6 +115,7 @@
     "name": "Earth Surge",
     "image": "Earth Surge.png",
     "max_hit": 23,
+    "base_xp": 48.5,
     "spellbook": "standard",
     "element": "earth"
   },
@@ -108,6 +123,7 @@
     "name": "Earth Wave",
     "image": "Earth Wave.png",
     "max_hit": 19,
+    "base_xp": 40,
     "spellbook": "standard",
     "element": "earth"
   },
@@ -115,6 +131,7 @@
     "name": "Enfeeble",
     "image": "Enfeeble.png",
     "max_hit": 0,
+    "base_xp": 83,
     "spellbook": "standard",
     "element": null
   },
@@ -122,6 +139,7 @@
     "name": "Entangle",
     "image": "Entangle.png",
     "max_hit": 5,
+    "base_xp": 89,
     "spellbook": "standard",
     "element": null
   },
@@ -129,6 +147,7 @@
     "name": "Fire Blast",
     "image": "Fire Blast.png",
     "max_hit": 16,
+    "base_xp": 34.5,
     "spellbook": "standard",
     "element": "fire"
   },
@@ -136,6 +155,7 @@
     "name": "Fire Bolt",
     "image": "Fire Bolt.png",
     "max_hit": 12,
+    "base_xp": 22.5,
     "spellbook": "standard",
     "element": "fire"
   },
@@ -143,6 +163,7 @@
     "name": "Fire Strike",
     "image": "Fire Strike.png",
     "max_hit": 8,
+    "base_xp": 11.5,
     "spellbook": "standard",
     "element": "fire"
   },
@@ -150,6 +171,7 @@
     "name": "Fire Surge",
     "image": "Fire Surge.png",
     "max_hit": 24,
+    "base_xp": 50.5,
     "spellbook": "standard",
     "element": "fire"
   },
@@ -157,6 +179,7 @@
     "name": "Fire Wave",
     "image": "Fire Wave.png",
     "max_hit": 20,
+    "base_xp": 42.5,
     "spellbook": "standard",
     "element": "fire"
   },
@@ -164,6 +187,7 @@
     "name": "Flames of Zamorak",
     "image": "Flames of Zamorak.png",
     "max_hit": 20,
+    "base_xp": 35,
     "spellbook": "standard",
     "element": null
   },
@@ -171,6 +195,7 @@
     "name": "Ghostly Grasp",
     "image": "Ghostly Grasp.png",
     "max_hit": 12,
+    "base_xp": 22.5,
     "spellbook": "arceuus",
     "element": null
   },
@@ -178,6 +203,7 @@
     "name": "Greater Corruption",
     "image": "Greater Corruption.png",
     "max_hit": 0,
+    "base_xp": 95,
     "spellbook": "arceuus",
     "element": null
   },
@@ -185,6 +211,7 @@
     "name": "Iban Blast",
     "image": "Iban Blast.png",
     "max_hit": 25,
+    "base_xp": 30,
     "spellbook": "standard",
     "element": null
   },
@@ -192,6 +219,7 @@
     "name": "Ice Barrage",
     "image": "Ice Barrage.png",
     "max_hit": 30,
+    "base_xp": 52,
     "spellbook": "ancient",
     "element": null
   },
@@ -199,6 +227,7 @@
     "name": "Ice Blitz",
     "image": "Ice Blitz.png",
     "max_hit": 26,
+    "base_xp": 46,
     "spellbook": "ancient",
     "element": null
   },
@@ -206,6 +235,7 @@
     "name": "Ice Burst",
     "image": "Ice Burst.png",
     "max_hit": 22,
+    "base_xp": 40,
     "spellbook": "ancient",
     "element": null
   },
@@ -213,6 +243,7 @@
     "name": "Ice Rush",
     "image": "Ice Rush.png",
     "max_hit": 16,
+    "base_xp": 34,
     "spellbook": "ancient",
     "element": null
   },
@@ -220,6 +251,7 @@
     "name": "Inferior Demonbane",
     "image": "Inferior Demonbane.png",
     "max_hit": 16,
+    "base_xp": 27,
     "spellbook": "arceuus",
     "element": null
   },
@@ -227,6 +259,7 @@
     "name": "Lesser Corruption",
     "image": "Lesser Corruption.png",
     "max_hit": 0,
+    "base_xp": 75,
     "spellbook": "arceuus",
     "element": null
   },
@@ -234,6 +267,7 @@
     "name": "Magic Dart",
     "image": "Magic Dart.png",
     "max_hit": 0,
+    "base_xp": 30,
     "spellbook": "standard",
     "element": null
   },
@@ -241,6 +275,7 @@
     "name": "Saradomin Strike",
     "image": "Saradomin Strike.png",
     "max_hit": 20,
+    "base_xp": 35,
     "spellbook": "standard",
     "element": null
   },
@@ -248,6 +283,7 @@
     "name": "Shadow Barrage",
     "image": "Shadow Barrage.png",
     "max_hit": 28,
+    "base_xp": 49,
     "spellbook": "ancient",
     "element": null
   },
@@ -255,6 +291,7 @@
     "name": "Shadow Blitz",
     "image": "Shadow Blitz.png",
     "max_hit": 24,
+    "base_xp": 43,
     "spellbook": "ancient",
     "element": null
   },
@@ -262,6 +299,7 @@
     "name": "Shadow Burst",
     "image": "Shadow Burst.png",
     "max_hit": 18,
+    "base_xp": 37,
     "spellbook": "ancient",
     "element": null
   },
@@ -269,6 +307,7 @@
     "name": "Shadow Rush",
     "image": "Shadow Rush.png",
     "max_hit": 14,
+    "base_xp": 31,
     "spellbook": "ancient",
     "element": null
   },
@@ -276,6 +315,7 @@
     "name": "Skeletal Grasp",
     "image": "Skeletal Grasp.png",
     "max_hit": 17,
+    "base_xp": 33,
     "spellbook": "arceuus",
     "element": null
   },
@@ -283,6 +323,7 @@
     "name": "Smoke Barrage",
     "image": "Smoke Barrage.png",
     "max_hit": 27,
+    "base_xp": 48,
     "spellbook": "ancient",
     "element": null
   },
@@ -290,6 +331,7 @@
     "name": "Smoke Blitz",
     "image": "Smoke Blitz.png",
     "max_hit": 23,
+    "base_xp": 42,
     "spellbook": "ancient",
     "element": null
   },
@@ -297,6 +339,7 @@
     "name": "Smoke Burst",
     "image": "Smoke Burst.png",
     "max_hit": 17,
+    "base_xp": 36,
     "spellbook": "ancient",
     "element": null
   },
@@ -304,6 +347,7 @@
     "name": "Smoke Rush",
     "image": "Smoke Rush.png",
     "max_hit": 13,
+    "base_xp": 30,
     "spellbook": "ancient",
     "element": null
   },
@@ -311,6 +355,7 @@
     "name": "Snare",
     "image": "Snare.png",
     "max_hit": 3,
+    "base_xp": 60,
     "spellbook": "standard",
     "element": null
   },
@@ -318,6 +363,7 @@
     "name": "Stun",
     "image": "Stun.png",
     "max_hit": 0,
+    "base_xp": 90,
     "spellbook": "standard",
     "element": null
   },
@@ -325,6 +371,7 @@
     "name": "Superior Demonbane",
     "image": "Superior Demonbane.png",
     "max_hit": 23,
+    "base_xp": 36,
     "spellbook": "arceuus",
     "element": null
   },
@@ -332,6 +379,7 @@
     "name": "Tele Block",
     "image": "Tele Block.png",
     "max_hit": 0,
+    "base_xp": 80,
     "spellbook": "standard",
     "element": null
   },
@@ -339,6 +387,7 @@
     "name": "Undead Grasp",
     "image": "Undead Grasp.png",
     "max_hit": 24,
+    "base_xp": 46.5,
     "spellbook": "arceuus",
     "element": null
   },
@@ -346,6 +395,7 @@
     "name": "Vulnerability",
     "image": "Vulnerability.png",
     "max_hit": 0,
+    "base_xp": 76,
     "spellbook": "standard",
     "element": null
   },
@@ -353,6 +403,7 @@
     "name": "Water Blast",
     "image": "Water Blast.png",
     "max_hit": 14,
+    "base_xp": 28.5,
     "spellbook": "standard",
     "element": "water"
   },
@@ -360,6 +411,7 @@
     "name": "Water Bolt",
     "image": "Water Bolt.png",
     "max_hit": 10,
+    "base_xp": 16.5,
     "spellbook": "standard",
     "element": "water"
   },
@@ -367,6 +419,7 @@
     "name": "Water Strike",
     "image": "Water Strike.png",
     "max_hit": 4,
+    "base_xp": 7.5,
     "spellbook": "standard",
     "element": "water"
   },
@@ -374,6 +427,7 @@
     "name": "Water Surge",
     "image": "Water Surge.png",
     "max_hit": 22,
+    "base_xp": 46.5,
     "spellbook": "standard",
     "element": "water"
   },
@@ -381,6 +435,7 @@
     "name": "Water Wave",
     "image": "Water Wave.png",
     "max_hit": 18,
+    "base_xp": 37.5,
     "spellbook": "standard",
     "element": "water"
   },
@@ -388,6 +443,7 @@
     "name": "Weaken",
     "image": "Weaken.png",
     "max_hit": 0,
+    "base_xp": 21,
     "spellbook": "standard",
     "element": null
   },
@@ -395,6 +451,7 @@
     "name": "Wind Blast",
     "image": "Wind Blast.png",
     "max_hit": 13,
+    "base_xp": 25.5,
     "spellbook": "standard",
     "element": "air"
   },
@@ -402,6 +459,7 @@
     "name": "Wind Bolt",
     "image": "Wind Bolt.png",
     "max_hit": 9,
+    "base_xp": 13.5,
     "spellbook": "standard",
     "element": "air"
   },
@@ -409,6 +467,7 @@
     "name": "Wind Strike",
     "image": "Wind Strike.png",
     "max_hit": 2,
+    "base_xp": 5.5,
     "spellbook": "standard",
     "element": "air"
   },
@@ -416,6 +475,7 @@
     "name": "Wind Surge",
     "image": "Wind Surge.png",
     "max_hit": 21,
+    "base_xp": 44.5,
     "spellbook": "standard",
     "element": "air"
   },
@@ -423,6 +483,7 @@
     "name": "Wind Wave",
     "image": "Wind Wave.png",
     "max_hit": 17,
+    "base_xp": 36,
     "spellbook": "standard",
     "element": "air"
   }

--- a/src/app/components/player/combat/SpellSelect.tsx
+++ b/src/app/components/player/combat/SpellSelect.tsx
@@ -23,6 +23,7 @@ const SpellSelect: React.FC = observer(() => {
       name: e.name,
       image: e.image,
       max_hit: e.max_hit,
+      base_xp: e.base_xp,
       spellbook: e.spellbook as Spellbook,
       element: e.element as Spellement,
     },

--- a/src/app/components/results/PlayerVsNPCResultsTable.tsx
+++ b/src/app/components/results/PlayerVsNPCResultsTable.tsx
@@ -28,6 +28,8 @@ const calcKeyToString = (value: number, calcKey: keyof PlayerVsNPCCalculatedLoad
     case 'dps':
     case 'specMomentDps':
       return value.toFixed(DPS_PRECISION);
+    case 'xpPerHour':
+      return value.toLocaleString(undefined, { maximumFractionDigits: 0 });
     case 'specFullDps':
       return value.toPrecision(DPS_PRECISION);
     case 'expectedHit':
@@ -142,6 +144,9 @@ const PlayerVsNPCResultsTable: React.FC = observer(() => {
         )}
         <ResultRow calcKey="dps" title="The average damage you will deal per-second" hasResults={hasResults}>
           DPS
+        </ResultRow>
+        <ResultRow calcKey="xpPerHour" title="The estimated combat XP per hour, based on damage dealt (4xp/damage for melee and ranged, 2xp/damage for magic, not including base spell cast xp)" hasResults={hasResults}>
+          XP/H
         </ResultRow>
         <ResultRow calcKey="ttk" title="The average time (in seconds) it will take to defeat the monster" hasResults={hasResults}>
           Avg. TTK

--- a/src/app/components/results/PlayerVsNPCResultsTable.tsx
+++ b/src/app/components/results/PlayerVsNPCResultsTable.tsx
@@ -145,7 +145,7 @@ const PlayerVsNPCResultsTable: React.FC = observer(() => {
         <ResultRow calcKey="dps" title="The average damage you will deal per-second" hasResults={hasResults}>
           DPS
         </ResultRow>
-        <ResultRow calcKey="xpPerHour" title="The estimated combat XP per hour, based on damage dealt (4xp/damage for melee and ranged, 2xp/damage for magic, not including base spell cast xp)" hasResults={hasResults}>
+        <ResultRow calcKey="xpPerHour" title="The estimated combat XP per hour (4xp/damage for melee and ranged, 2xp/damage for magic, plus base spell cast xp where applicable)" hasResults={hasResults}>
           XP/H
         </ResultRow>
         <ResultRow calcKey="ttk" title="The average time (in seconds) it will take to defeat the monster" hasResults={hasResults}>

--- a/src/lib/PlayerVsNPCCalc.ts
+++ b/src/lib/PlayerVsNPCCalc.ts
@@ -2007,6 +2007,15 @@ export default class PlayerVsNPCCalc extends BaseCalc {
   }
 
   /**
+   * Returns the expected combat XP gained per hour, based on damage dealt.
+   * Magic grants 2xp per point of damage; all other combat styles grant 4xp per point of damage.
+   */
+  public getXpPerHour() {
+    const xpPerDamage = this.player.style.type === 'magic' ? 2 : 4;
+    return this.getDps() * xpPerDamage * 3600;
+  }
+
+  /**
    * Returns the amount of time (in ticks) that the user can maintain their prayers before running out of prayer points.
    * Does not account for flicking or toggling prayers.
    */

--- a/src/lib/PlayerVsNPCCalc.ts
+++ b/src/lib/PlayerVsNPCCalc.ts
@@ -2007,12 +2007,21 @@ export default class PlayerVsNPCCalc extends BaseCalc {
   }
 
   /**
-   * Returns the expected combat XP gained per hour, based on damage dealt.
-   * Magic grants 2xp per point of damage; all other combat styles grant 4xp per point of damage.
+   * Returns the expected combat XP gained per hour.
+   * Magic grants 2xp per point of damage, plus a fixed base XP per cast (awarded on hit or miss) for spells
+   * cast from the spellbook. All other combat styles grant 4xp per point of damage.
    */
   public getXpPerHour() {
-    const xpPerDamage = this.player.style.type === 'magic' ? 2 : 4;
-    return this.getDps() * xpPerDamage * 3600;
+    const isMagic = this.player.style.type === 'magic';
+    const xpPerDamage = isMagic ? 2 : 4;
+    const damageXpPerHour = this.getDps() * xpPerDamage * 3600;
+
+    if (isMagic && this.player.spell?.base_xp) {
+      const castsPerHour = 3600 / (this.getExpectedAttackSpeed() * SECONDS_PER_TICK);
+      return damageXpPerHour + (this.player.spell.base_xp * castsPerHour);
+    }
+
+    return damageXpPerHour;
   }
 
   /**

--- a/src/state.tsx
+++ b/src/state.tsx
@@ -241,6 +241,7 @@ class GlobalState implements State {
         playerDefRoll: 0,
         accuracy: 0,
         dps: 0,
+        xpPerHour: 0,
         ttk: 0,
         hitDist: [],
         ttkDist: undefined,

--- a/src/types/Spell.ts
+++ b/src/types/Spell.ts
@@ -4,6 +4,7 @@ export interface Spell {
   name: string;
   image: string;
   max_hit: number;
+  base_xp: number;
   spellbook: Spellbook;
   element: Spellement;
 }

--- a/src/types/State.ts
+++ b/src/types/State.ts
@@ -55,6 +55,7 @@ export interface PlayerVsNPCCalculatedLoadout extends CalculatedLoadout {
   maxAttackRoll?: number,
   accuracy?: number,
   dps?: number,
+  xpPerHour?: number,
   ttk?: number,
   hitDist?: ChartEntry[],
   ttkDist?: Map<number, number>,

--- a/src/worker/worker.ts
+++ b/src/worker/worker.ts
@@ -39,6 +39,7 @@ const computePvMValues: Handler<WorkerRequestType.COMPUTE_BASIC> = async (data) 
       maxAttackRoll: calc.getMaxAttackRoll(),
       accuracy: calc.getDisplayHitChance(),
       dps: calc.getDps(),
+      xpPerHour: calc.getXpPerHour(),
       ttk: calc.getTtk(),
       hitDist: calc.getDistribution().asHistogram(calcOpts.hitDistHideMisses),
       details: calc.details,


### PR DESCRIPTION
## Summary
* Adds a new "XP/H" row to the loadout results table, showing estimated combat XP per hour for the selected loadout against the selected monster.
* Melee and ranged: `dps * 4 * 3600`.
* Magic: `(dps * 2 * 3600) + (spell base XP * casts per hour)`. Magic combat XP isn't purely damage-based — each cast also grants a fixed base XP amount regardless of hit or miss, which varies per spell. Base XP values were sourced from the OSRS Wiki and added to `cdn/json/spells.json` as a new `base_xp` field for all 61 combat spells the tool supports.

## Justification
The results table already surfaces DPS, Max hit, and Avg. TTK per loadout, but doesn't show the resulting XP rate, which is one of the main things players compare loadouts for (not just kill speed). This adds that as a small, self-contained derived stat.

## Implementation
* `PlayerVsNPCCalc.getXpPerHour()` — new method alongside `getDps()`.
* `worker.ts` — wires the new value into the computed loadout result.
* `types/State.ts` / `state.tsx` — adds `xpPerHour` to the loadout type and default state.
* `types/Spell.ts` / `SpellSelect.tsx` — adds `base_xp` to the `Spell` type and wires it through spell selection.
* `cdn/json/spells.json` — adds `base_xp` per spell.
* `PlayerVsNPCResultsTable.tsx` — new "XP/H" row and number formatting.

## Test plan
- [x] `yarn lint` passes with no warnings/errors
- [x] `yarn test` passes (25/25 suites, 289/289 tests)
- [x] Manually verified in `yarn dev` against a real character/loadout: melee, ranged, and magic (including base spell cast XP) produce sensible XP/H values that match the expected in-game rate (cross-checked against RuneLite's XP tracker)