### PR TITLE
Include accuracy demonbane factor for darklight/silverlight

### DIFF
--- a/src/lib/PlayerVsNPCCalc.ts
+++ b/src/lib/PlayerVsNPCCalc.ts
@@ -255,6 +255,9 @@ export default class PlayerVsNPCCalc extends BaseCalc {
     if (this.wearing(['Arclight', 'Emberlight']) && mattrs.includes(MonsterAttribute.DEMON)) {
       attackRoll = this.trackAddFactor(DetailKey.PLAYER_ACCURACY_DEMONBANE, attackRoll, this.demonbaneFactor(70));
     }
+    if (this.wearing(['Silverlight', 'Darklight']) && mattrs.includes(MonsterAttribute.DEMON)) {
+      attackRoll = this.trackAddFactor(DetailKey.PLAYER_ACCURACY_DEMONBANE, attackRoll, this.demonbaneFactor(60));
+    }
     if (this.wearing(['Bone claws', 'Burning claws']) && mattrs.includes(MonsterAttribute.DEMON)) {
       attackRoll = this.trackAddFactor(DetailKey.PLAYER_ACCURACY_DEMONBANE, attackRoll, this.demonbaneFactor(5));
     }


### PR DESCRIPTION
Testing by Rhysdog found that darklight and silverlight do have demonbane accuracy bonus (as mentioned in game). From gearscape discord: https://discord.com/channels/822076378056228915/1521176396905447497/1521179597117329459

Note that dyed silverlight is also named Silverlight and does not need a separate condition. An existing PR (#891) already removes the unused Silverlight (dyed) from the max hit factor

Manually verified in yarn dev
<img width="935" height="88" alt="image" src="https://github.com/user-attachments/assets/55154b9d-1d9d-4a0e-8845-74fbd71bce4e" />